### PR TITLE
ci(monitor-scan): hourly snapshot scanner workflow

### DIFF
--- a/.github/workflows/monitor-scan.yml
+++ b/.github/workflows/monitor-scan.yml
@@ -1,0 +1,47 @@
+name: monitor-scan
+
+# Snapshots every project's checklist + DB rows + live status into the
+# monitor_snapshots table. The deployed Utopia Fairy monitor reads from there.
+
+on:
+  schedule:
+    # Hourly at minute 7 (offset to avoid the rush of jobs at :00).
+    - cron: '7 * * * *'
+  push:
+    branches: [main]
+    paths:
+      - 'projects/**'
+      - 'utopia-fairy/**'
+      - '.github/workflows/monitor-scan.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: monitor-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: utopia-fairy/package-lock.json
+
+      - name: Install utopia-fairy deps
+        working-directory: utopia-fairy
+        run: npm ci
+
+      - name: Run scanner
+        working-directory: utopia-fairy
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npm run scan


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/monitor-scan.yml` so the deployed Utopia Fairy monitor can stay up-to-date via a cron-driven scan.
- Triggers: hourly at minute 7, on push to `main` touching `projects/**` or `utopia-fairy/**`, and `workflow_dispatch`.
- Cherry-picked from the `mac-mini` branch so this PR is workflow-file-only — none of the monitor code itself is in this PR (that's still on `mac-mini`).

## Why it lives on main
GitHub only fires scheduled / workflow_dispatch runs from the **default branch**. Without this on `main` the hourly cron won't run.

## Prerequisites already in place
- Repo secrets `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` are set.
- The `monitor_snapshots` table exists in Supabase (run via SQL editor).
- Deployed monitor: <https://utopia-fairy-monitor-qizwmg0r8.utopiaai.my> (401-protected by default).

## Test plan
- [ ] Merge.
- [ ] Trigger manually: Actions → `monitor-scan` → Run workflow.
- [ ] Confirm the run succeeds (~3–5 min).
- [ ] Check `monitor_snapshots.ran_at` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)