### PR TITLE
feat(utopia-fairy): monitor dashboard for every project

### DIFF
--- a/utopia-fairy/DEPLOY.md
+++ b/utopia-fairy/DEPLOY.md
@@ -1,0 +1,163 @@
+# Deploying Utopia Fairy as a hosted monitor
+
+The monitor has two modes:
+
+| Mode | When | Data source |
+|---|---|---|
+| **live** | Local dev (`npm run dev` inside this folder) | Runs all 35 checks on-demand against the local `projects/` folder + Supabase + live websites |
+| **snapshot** | Deployed (Vercel) | Reads pre-computed results from the `monitor_snapshots` table |
+
+The CI scanner (`.github/workflows/monitor-scan.yml`) writes snapshots hourly. The deployed monitor reads them — it has no filesystem access to `projects/`.
+
+---
+
+## One-time setup
+
+### 1. Create the snapshot table
+
+Run [supabase/migrations/20260520_monitor_snapshots.sql](supabase/migrations/20260520_monitor_snapshots.sql) in the Supabase SQL Editor.
+
+Verify it worked:
+
+```sql
+select count(*) from monitor_snapshots;  -- → 0
+```
+
+### 2. Seed the first snapshot (optional — proves the local scanner works)
+
+From the repo root:
+
+```bash
+cd utopia-fairy
+npm install   # picks up tsx
+npm run scan
+```
+
+Expected output (each line ≈ 4–5 s):
+
+```
+scan: 16 project(s) under .../projects
+  ✓ coldroom-malaysia                    35/35 · live=connected · 4938ms
+  ✓ electric-wheelchair-malaysia         34/35 · live=connected · 5102ms
+  ...
+scan: done · 16 ok · 0 failed
+```
+
+Confirm the rows are there:
+
+```bash
+curl "$NEXT_PUBLIC_SUPABASE_URL/rest/v1/monitor_snapshots?select=slug,passed,total,ran_at" \
+  -H "apikey: $NEXT_PUBLIC_SUPABASE_ANON_KEY"
+```
+
+### 3. Preview deployed mode locally
+
+```bash
+UTOPIA_FAIRY_USE_SNAPSHOTS=1 npm run dev
+```
+
+The monitor now reads from `monitor_snapshots` instead of the local filesystem. It should look identical to the live mode, but with a `ran_at` timestamp at the top.
+
+---
+
+## CI: hourly snapshot job
+
+The workflow lives at [.github/workflows/monitor-scan.yml](../.github/workflows/monitor-scan.yml). It runs:
+
+- Every hour (minute 7)
+- On every push to `main` that touches `projects/**` or `utopia-fairy/**`
+- Manually via the Actions tab → workflow_dispatch
+
+**Add these repository secrets** (Settings → Secrets and variables → Actions → New repository secret):
+
+| Secret | Value |
+|---|---|
+| `SUPABASE_URL` | Same as `NEXT_PUBLIC_SUPABASE_URL` in `.env.local` |
+| `SUPABASE_ANON_KEY` | Same as `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
+| `SUPABASE_SERVICE_ROLE_KEY` | The service role key (write permission) |
+
+Trigger one run manually to verify the workflow works before relying on the cron.
+
+---
+
+## Vercel deployment
+
+### Create the project
+
+From the repo root:
+
+```bash
+cd utopia-fairy
+vercel link
+```
+
+Or in the Vercel dashboard:
+
+1. Import the `utopia-website-builder` GitHub repo
+2. **Root directory** → `utopia-fairy`
+3. Framework preset: Next.js
+
+### Environment variables (Vercel project settings)
+
+| Variable | Value | Notes |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | from `.env.local` | Required |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | from `.env.local` | Required |
+| `UTOPIA_FAIRY_USE_SNAPSHOTS` | `1` | Forces snapshot mode — otherwise it auto-detects but explicit is safer |
+
+**Do NOT** set `SUPABASE_SERVICE_ROLE_KEY` on Vercel. The deployed app should only ever read; writes happen exclusively from the CI scanner.
+
+### Password-protect the deployment
+
+In Vercel: Project Settings → Deployment Protection → Password Protection → enable, set a password, save.
+
+This locks every preview and production URL behind a single shared password (Pro plan).
+
+### Deploy
+
+```bash
+vercel --prod
+```
+
+The first deployment may show "0 projects" until the scanner has populated the table. Trigger the GitHub Actions workflow once via `workflow_dispatch` to seed it.
+
+---
+
+## What's in a snapshot
+
+Each row in `monitor_snapshots`:
+
+```
+slug                — primary key (project folder name)
+ran_at              — when the scan ran
+total, passed,
+  failed_count      — top-line score
+domain,
+  product_slug,
+  fallback_phone,
+  deploy_url        — parsed from config/site.ts + .vercel/
+domain_candidates   — every alias considered (slug, alias, custom domain, ...)
+groups              — full checklist groups[] with per-item status & detail
+registered          — company_websites rows matched
+phones              — phone_numbers rows for this site
+products            — products + product_photos
+blogs               — blog_posts + locale list
+hardcoded           — file-scan phone hits
+blog_hardcoded      — blog-content phone hits
+live_status         — { status, livePhone, dbPhones, fallbackPhone, detail }
+```
+
+Removing a project folder removes its snapshot on the next scan (the scanner prunes rows whose slug no longer exists).
+
+---
+
+## Updating
+
+When you add a new checklist item to `lib/checklist.ts`, the snapshot's `total` column will reflect it immediately on the next scan — no migration needed. The jsonb columns absorb new fields without schema changes.
+
+If you change the schema in a backwards-incompatible way (rare), drop and re-create the table:
+
+```sql
+drop table monitor_snapshots;
+-- then re-run the migration
+```

--- a/utopia-fairy/app/api/checklist/[slug]/route.ts
+++ b/utopia-fairy/app/api/checklist/[slug]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { runChecklist } from '@/lib/runChecklist'
+import { dataMode, projectsDir } from '@/lib/dataSource'
+import { readSnapshot } from '@/lib/snapshotStore'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  try {
+    if (dataMode() === 'snapshot') {
+      const row = await readSnapshot(slug)
+      if (!row) return NextResponse.json({ error: `no snapshot for ${slug}` }, { status: 404 })
+      return NextResponse.json({
+        slug: row.slug,
+        domain: row.domain,
+        productSlug: row.product_slug,
+        deployUrl: row.deploy_url,
+        passed: row.passed,
+        total: row.total,
+        failedCount: row.failed_count,
+        groups: row.groups,
+        ranAt: row.ran_at,
+        mode: 'snapshot',
+      })
+    }
+    const run = await runChecklist(slug, projectsDir())
+    return NextResponse.json({ ...run, mode: 'live' })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/utopia-fairy/app/api/checklist/route.ts
+++ b/utopia-fairy/app/api/checklist/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server'
+import { readdir, stat } from 'fs/promises'
+import path from 'path'
+import { runChecklist } from '@/lib/runChecklist'
+import { totalCheckCount } from '@/lib/checklist'
+import { dataMode, projectsDir } from '@/lib/dataSource'
+import { readAllSnapshots } from '@/lib/snapshotStore'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  if (dataMode() === 'snapshot') {
+    return serveFromSnapshots()
+  }
+  return serveLive()
+}
+
+async function serveLive() {
+  try {
+    const dir = projectsDir()
+    const entries = await readdir(dir)
+
+    const slugs: { slug: string; createdAt: string }[] = []
+    for (const slug of entries) {
+      try {
+        const s = await stat(path.join(dir, slug, 'inputs.md'))
+        slugs.push({ slug, createdAt: s.mtime.toISOString() })
+      } catch { /* not a project */ }
+    }
+
+    const runs = await Promise.all(
+      slugs.map(({ slug, createdAt }) =>
+        runChecklist(slug, dir)
+          .then((r) => ({
+            slug,
+            domain: r.domain,
+            productSlug: r.productSlug,
+            deployUrl: r.deployUrl,
+            passed: r.passed,
+            total: r.total,
+            failedCount: r.failedCount,
+            groups: r.groups.map((g) => ({
+              name: g.name,
+              passed: g.items.filter((i) => i.status === 'pass').length,
+              total: g.items.length,
+            })),
+            createdAt,
+          }))
+          .catch(() => null),
+      ),
+    )
+
+    const projects = runs.filter(Boolean)
+    projects.sort((a, b) => new Date(b!.createdAt).getTime() - new Date(a!.createdAt).getTime())
+
+    return NextResponse.json({
+      projects,
+      totalChecks: totalCheckCount(),
+      mode: 'live',
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { projects: [], totalChecks: totalCheckCount(), mode: 'live', error: e instanceof Error ? e.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+async function serveFromSnapshots() {
+  try {
+    const rows = await readAllSnapshots()
+    const projects = rows.map((r) => ({
+      slug: r.slug,
+      domain: r.domain,
+      productSlug: r.product_slug,
+      deployUrl: r.deploy_url,
+      passed: r.passed,
+      total: r.total,
+      failedCount: r.failed_count,
+      groups: (r.groups as { name: string; items: { status: string }[] }[]).map((g) => ({
+        name: g.name,
+        passed: g.items.filter((i) => i.status === 'pass').length,
+        total: g.items.length,
+      })),
+      createdAt: r.ran_at,
+    }))
+    // Sort newest first by ran_at; ties keep original (already sorted by Supabase).
+    return NextResponse.json({
+      projects,
+      totalChecks: projects[0]?.total ?? 0,
+      mode: 'snapshot',
+      ranAt: rows[0]?.ran_at ?? null,
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { projects: [], totalChecks: 0, mode: 'snapshot', error: e instanceof Error ? e.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/utopia-fairy/app/api/wish-data/[slug]/route.ts
+++ b/utopia-fairy/app/api/wish-data/[slug]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { getExpandedProjectInfo } from '@/lib/runChecklist'
+import {
+  getPhoneRows,
+  getProductRows,
+  getBlogRows,
+  getBlogContentRows,
+  getRegisteredDomains,
+} from '@/lib/supabaseChecks'
+import { findHardcodedPhones, findBlogHardcodedPhones } from '@/lib/sourceScan'
+import { checkLiveDbConnection } from '@/lib/liveStatusCheck'
+import { dataMode, projectsDir } from '@/lib/dataSource'
+import { readSnapshot } from '@/lib/snapshotStore'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  try {
+    if (dataMode() === 'snapshot') {
+      const row = await readSnapshot(slug)
+      if (!row) return NextResponse.json({ error: `no snapshot for ${slug}` }, { status: 404 })
+      return NextResponse.json({
+        slug: row.slug,
+        domain: row.domain,
+        fallbackPhone: row.fallback_phone,
+        domainCandidates: row.domain_candidates,
+        registered: row.registered,
+        phones: row.phones,
+        products: row.products,
+        blogs: row.blogs,
+        hardcoded: row.hardcoded ?? [],
+        blogHardcoded: row.blog_hardcoded ?? [],
+        liveStatus: row.live_status,
+        ranAt: row.ran_at,
+        mode: 'snapshot',
+      })
+    }
+
+    const info = await getExpandedProjectInfo(slug, projectsDir())
+
+    const [registered, phones, products, blogs, blogContent, hardcoded] = await Promise.all([
+      getRegisteredDomains(info.domainCandidates),
+      getPhoneRows(info.domainCandidates),
+      getProductRows(info.domainCandidates),
+      getBlogRows(info.domainCandidates),
+      getBlogContentRows(info.domainCandidates),
+      findHardcodedPhones(info.projectDir),
+    ])
+
+    const blogHardcoded = findBlogHardcodedPhones(blogContent)
+
+    const candidateBaseUrls: string[] = []
+    if (registered) for (const r of registered) candidateBaseUrls.push(`https://${r.domain}`)
+    if (info.deployUrl) candidateBaseUrls.push(info.deployUrl)
+    for (const d of info.domainCandidates) {
+      const u = `https://${d}`
+      if (!candidateBaseUrls.includes(u)) candidateBaseUrls.push(u)
+    }
+    const dbPhones = Array.from(new Set((phones ?? []).filter((p) => p.is_active).map((p) => p.phone_number)))
+    const liveStatus = await checkLiveDbConnection({
+      baseUrls: Array.from(new Set(candidateBaseUrls)),
+      dbPhones,
+      fallbackPhone: info.fallbackPhone,
+    })
+
+    return NextResponse.json({
+      slug,
+      domain: info.domain,
+      fallbackPhone: info.fallbackPhone,
+      domainCandidates: info.domainCandidates,
+      registered,
+      phones,
+      products,
+      blogs,
+      hardcoded,
+      blogHardcoded,
+      liveStatus,
+      mode: 'live',
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/utopia-fairy/app/layout.tsx
+++ b/utopia-fairy/app/layout.tsx
@@ -25,9 +25,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div style={{
           display: 'flex',
           justifyContent: 'center',
-          alignItems: 'center',
+          alignItems: 'flex-start',
           minHeight: '100vh',
-          padding: '80px 16px',
+          padding: '60px 16px',
         }}>
           {children}
         </div>

--- a/utopia-fairy/app/new/page.tsx
+++ b/utopia-fairy/app/new/page.tsx
@@ -1,0 +1,63 @@
+import GenieForm from '@/components/GenieForm'
+
+export default function NewWishPage() {
+  return (
+    <main style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      textAlign: 'center',
+      gap: 6,
+      width: '100%',
+      maxWidth: 560,
+      margin: '0 auto',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 4 }}>
+        <div className="fairy-container fade-in">
+          <div className="fairy-glow" />
+          <img
+            src="/fairy.gif"
+            alt="Utopia Fairy"
+            style={{
+              width: 80,
+              height: 80,
+              objectFit: 'contain',
+              filter: 'drop-shadow(0 0 15px rgba(79, 195, 247, 0.4))',
+            }}
+          />
+        </div>
+      </div>
+      <h1
+        className="fade-in"
+        style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 34,
+          fontWeight: 400,
+          color: 'var(--accent-fairy)',
+          letterSpacing: '3px',
+          margin: 0,
+          textShadow: '0 0 30px rgba(129, 212, 250, 0.3)',
+        }}
+      >
+        Utopia Fairy
+      </h1>
+      <p
+        className="fade-in"
+        style={{
+          color: 'var(--text-muted)',
+          fontSize: 14,
+          marginBottom: 20,
+          fontFamily: 'var(--font-body)',
+          fontWeight: 500,
+          letterSpacing: '0.3px',
+          animationDelay: '0.15s',
+        }}
+      >
+        Your wish is my command — what website shall I create today?
+      </p>
+      <div className="fade-in" style={{ animationDelay: '0.3s' }}>
+        <GenieForm />
+      </div>
+    </main>
+  )
+}

--- a/utopia-fairy/app/page.tsx
+++ b/utopia-fairy/app/page.tsx
@@ -1,63 +1,13 @@
-import GenieForm from '@/components/GenieForm'
+import MonitorTable from '@/components/MonitorTable'
 
 export default function Home() {
   return (
-    <main style={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'stretch',
-      textAlign: 'center',
-      gap: 6,
+    <main className="fade-in" style={{
       width: '100%',
-      maxWidth: 560,
+      maxWidth: 1400,
       margin: '0 auto',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 4 }}>
-        <div className="fairy-container fade-in">
-          <div className="fairy-glow" />
-          <img
-            src="/fairy.gif"
-            alt="Utopia Fairy"
-            style={{
-              width: 80,
-              height: 80,
-              objectFit: 'contain',
-              filter: 'drop-shadow(0 0 15px rgba(79, 195, 247, 0.4))',
-            }}
-          />
-        </div>
-      </div>
-      <h1
-        className="fade-in"
-        style={{
-          fontFamily: 'var(--font-display)',
-          fontSize: 34,
-          fontWeight: 400,
-          color: 'var(--accent-fairy)',
-          letterSpacing: '3px',
-          margin: 0,
-          textShadow: '0 0 30px rgba(129, 212, 250, 0.3)',
-        }}
-      >
-        Utopia Fairy
-      </h1>
-      <p
-        className="fade-in"
-        style={{
-          color: 'var(--text-muted)',
-          fontSize: 14,
-          marginBottom: 20,
-          fontFamily: 'var(--font-body)',
-          fontWeight: 500,
-          letterSpacing: '0.3px',
-          animationDelay: '0.15s',
-        }}
-      >
-        Your wish is my command — what website shall I create today?
-      </p>
-      <div className="fade-in" style={{ animationDelay: '0.3s' }}>
-        <GenieForm />
-      </div>
+      <MonitorTable />
     </main>
   )
 }

--- a/utopia-fairy/app/wish/[slug]/WishStatus.tsx
+++ b/utopia-fairy/app/wish/[slug]/WishStatus.tsx
@@ -270,7 +270,7 @@ export default function WishStatus({ slug }: { slug: string }) {
           fontFamily: 'var(--font-body)',
         }}
       >
-        ✧ Make another wish
+        ← Back to Monitor
       </button>
     </div>
   )

--- a/utopia-fairy/app/wish/[slug]/page.tsx
+++ b/utopia-fairy/app/wish/[slug]/page.tsx
@@ -1,4 +1,7 @@
+import Link from 'next/link'
 import WishStatus from './WishStatus'
+import WishChecklist from '@/components/WishChecklist'
+import WishData from '@/components/WishData'
 
 export default async function WishPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
@@ -10,18 +13,41 @@ export default async function WishPage({ params }: { params: Promise<{ slug: str
       alignItems: 'center',
       gap: 6,
       width: '100%',
-      maxWidth: 600,
+      maxWidth: 760,
     }}>
+      <div className="fade-in" style={{ width: '100%', display: 'flex', justifyContent: 'flex-start', marginBottom: 8 }}>
+        <Link
+          href="/"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            background: 'rgba(79, 195, 247, 0.08)',
+            border: '1px solid var(--input-border)',
+            borderRadius: 10,
+            padding: '8px 14px',
+            color: 'var(--accent-fairy)',
+            fontSize: 12,
+            fontWeight: 600,
+            textDecoration: 'none',
+            fontFamily: 'var(--font-body)',
+            letterSpacing: '0.3px',
+          }}
+        >
+          ← Back to Monitor
+        </Link>
+      </div>
       <h1
         className="fade-in"
         style={{
           fontFamily: 'var(--font-display)',
-          fontSize: 34,
+          fontSize: 'clamp(26px, 6vw, 34px)',
           fontWeight: 400,
           color: 'var(--accent-fairy)',
           letterSpacing: '3px',
           margin: 0,
           textShadow: '0 0 30px rgba(129, 212, 250, 0.3)',
+          textAlign: 'center',
         }}
       >
         Utopia Fairy
@@ -36,12 +62,21 @@ export default async function WishPage({ params }: { params: Promise<{ slug: str
           fontWeight: 500,
           letterSpacing: '0.3px',
           animationDelay: '0.15s',
+          textAlign: 'center',
         }}
       >
         Your wish is being granted...
       </p>
       <div className="fade-in" style={{ width: '100%', animationDelay: '0.3s' }}>
         <WishStatus slug={slug} />
+      </div>
+
+      <div className="fade-in" style={{ width: '100%', marginTop: 40, animationDelay: '0.45s' }}>
+        <WishChecklist slug={slug} />
+      </div>
+
+      <div className="fade-in" style={{ width: '100%', marginTop: 40, animationDelay: '0.6s' }}>
+        <WishData slug={slug} />
       </div>
     </main>
   )

--- a/utopia-fairy/components/MonitorTable.tsx
+++ b/utopia-fairy/components/MonitorTable.tsx
@@ -1,0 +1,490 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useIsMobile } from '@/lib/useMediaQuery'
+
+interface GroupSummary {
+  name: string
+  passed: number
+  total: number
+}
+
+interface ProjectRow {
+  slug: string
+  domain: string | null
+  productSlug: string | null
+  deployUrl: string | null
+  passed: number
+  total: number
+  failedCount: number
+  groups: GroupSummary[]
+  createdAt: string
+}
+
+interface MonitorPayload {
+  projects: ProjectRow[]
+  totalChecks: number
+}
+
+const STATE_COLORS = {
+  perfect: { bg: 'rgba(74, 222, 128, 0.12)', border: 'rgba(74, 222, 128, 0.35)', fg: '#4ade80' },
+  partial: { bg: 'rgba(249, 169, 106, 0.10)', border: 'rgba(249, 169, 106, 0.30)', fg: '#F9A96A' },
+  failing: { bg: 'rgba(248, 113, 113, 0.10)', border: 'rgba(248, 113, 113, 0.30)', fg: '#f87171' },
+  empty:   { bg: 'rgba(96, 112, 128, 0.08)', border: 'rgba(96, 112, 128, 0.25)', fg: '#7a8ea3' },
+} as const
+
+function tierOf(p: ProjectRow): keyof typeof STATE_COLORS {
+  if (p.total === 0) return 'empty'
+  const ratio = p.passed / p.total
+  if (ratio >= 1) return 'perfect'
+  if (ratio >= 0.6) return 'partial'
+  return 'failing'
+}
+
+export default function MonitorTable() {
+  const [data, setData] = useState<MonitorPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
+  const isMobile = useIsMobile()
+
+  useEffect(() => {
+    let mounted = true
+    const load = async () => {
+      try {
+        const res = await fetch('/api/checklist', { cache: 'no-store' })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json: MonitorPayload = await res.json()
+        if (mounted) {
+          setData(json)
+          setError(null)
+        }
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : 'failed to load')
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    load()
+    const t = setInterval(load, 30_000)
+    return () => { mounted = false; clearInterval(t) }
+  }, [])
+
+  const groupNames = data?.projects[0]?.groups.map((g) => g.name) ?? []
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: '100%' }}>
+      {/* Header — fairy gif → title → subtitle → CTA, centered on mobile */}
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        alignItems: isMobile ? 'center' : 'flex-start',
+        textAlign: isMobile ? 'center' : 'left',
+      }}>
+        <div className="fairy-container fade-in" style={{ marginBottom: 2 }}>
+          <div className="fairy-glow" />
+          <img
+            src="/fairy.gif"
+            alt="Utopia Fairy"
+            style={{
+              width: isMobile ? 64 : 72,
+              height: isMobile ? 64 : 72,
+              objectFit: 'contain',
+              filter: 'drop-shadow(0 0 15px rgba(79, 195, 247, 0.4))',
+            }}
+          />
+        </div>
+        <h1 style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: isMobile ? 30 : 38,
+          fontWeight: 400,
+          color: 'var(--accent-fairy)',
+          letterSpacing: isMobile ? '2px' : '3px',
+          margin: 0,
+          textShadow: '0 0 30px rgba(129, 212, 250, 0.3)',
+        }}>
+          Utopia Monitor
+        </h1>
+        <p style={{
+          color: 'var(--text-muted)',
+          fontSize: isMobile ? 12 : 13,
+          fontFamily: 'var(--font-body)',
+          letterSpacing: '0.3px',
+          margin: 0,
+          maxWidth: 560,
+        }}>
+          {loading
+            ? 'Reading every project under projects/…'
+            : `${data?.projects.length ?? 0} project${(data?.projects.length ?? 0) === 1 ? '' : 's'} · ${data?.totalChecks ?? 0} checks per project · auto-refresh every 30s`}
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button
+            onClick={() => router.push('/new')}
+            style={{
+              background: 'linear-gradient(135deg, var(--accent-deep), var(--accent-glow))',
+              border: 'none',
+              borderRadius: 10,
+              padding: '10px 22px',
+              color: 'white',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+              fontFamily: 'var(--font-body)',
+              boxShadow: '0 4px 15px rgba(79, 195, 247, 0.25)',
+            }}
+          >
+            ✦ New Wish
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{
+          background: 'rgba(248, 113, 113, 0.08)',
+          border: '1px solid rgba(248, 113, 113, 0.25)',
+          borderRadius: 10,
+          padding: '12px 16px',
+          color: '#f87171',
+          fontSize: 13,
+        }}>
+          {error}
+        </div>
+      )}
+
+      {/* Desktop: data table. Mobile: card list. */}
+      {isMobile ? (
+        <MobileCards
+          projects={data?.projects ?? []}
+          loading={loading}
+          onOpen={(slug) => router.push(`/wish/${slug}`)}
+        />
+      ) : (
+      <div style={{
+        background: 'rgba(10, 22, 40, 0.55)',
+        border: '1px solid var(--input-border)',
+        borderRadius: 14,
+        overflow: 'hidden',
+        backdropFilter: 'blur(8px)',
+      }}>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            minWidth: 980,
+          }}>
+            <thead>
+              <tr style={{
+                background: 'rgba(79, 195, 247, 0.05)',
+                borderBottom: '1px solid var(--input-border)',
+              }}>
+                <Th>Project</Th>
+                <Th>Domain</Th>
+                {groupNames.map((g) => <Th key={g} compact>{g}</Th>)}
+                <Th align="right">Score</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data?.projects ?? []).map((p) => {
+                const tier = tierOf(p)
+                const c = STATE_COLORS[tier]
+                return (
+                  <tr
+                    key={p.slug}
+                    onClick={() => router.push(`/wish/${p.slug}`)}
+                    style={{
+                      borderTop: '1px solid var(--input-border)',
+                      cursor: 'pointer',
+                      transition: 'background 0.15s',
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(79, 195, 247, 0.04)' }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
+                  >
+                    <Td>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                        <span style={{ color: 'var(--text-primary)', fontWeight: 600 }}>{p.slug}</span>
+                        {p.deployUrl && (
+                          <span style={{ color: 'var(--text-muted)', fontSize: 10, opacity: 0.7 }}>
+                            {new URL(p.deployUrl).host}
+                          </span>
+                        )}
+                      </div>
+                    </Td>
+                    <Td>
+                      <span style={{ color: 'var(--text-muted)', fontFamily: 'monospace', fontSize: 11 }}>
+                        {p.domain ?? '—'}
+                      </span>
+                    </Td>
+                    {p.groups.map((g) => (
+                      <Td key={g.name} compact align="center">
+                        <GroupChip passed={g.passed} total={g.total} />
+                      </Td>
+                    ))}
+                    <Td align="right">
+                      <span style={{
+                        background: c.bg,
+                        border: `1px solid ${c.border}`,
+                        color: c.fg,
+                        padding: '4px 10px',
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        letterSpacing: '0.3px',
+                        display: 'inline-block',
+                        minWidth: 60,
+                        textAlign: 'center',
+                      }}>
+                        {p.passed} / {p.total}
+                      </span>
+                    </Td>
+                  </tr>
+                )
+              })}
+
+              {!loading && data && data.projects.length === 0 && (
+                <tr>
+                  <td colSpan={2 + groupNames.length + 1} style={{
+                    color: 'var(--text-muted)',
+                    fontSize: 13,
+                    textAlign: 'center',
+                    padding: '32px 16px',
+                    opacity: 0.6,
+                  }}>
+                    No projects with inputs.md found under projects/
+                  </td>
+                </tr>
+              )}
+
+              {loading && (
+                <tr>
+                  <td colSpan={2 + 1} style={{
+                    color: 'var(--text-muted)',
+                    fontSize: 13,
+                    textAlign: 'center',
+                    padding: '32px 16px',
+                    opacity: 0.6,
+                  }}>
+                    ✦ Running checks…
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      )}
+
+      <p style={{
+        color: 'var(--text-muted)',
+        fontSize: 11,
+        opacity: 0.55,
+        fontFamily: 'var(--font-body)',
+        margin: 0,
+      }}>
+        Tip: click any row to see the full breakdown and the list of items still to implement.
+      </p>
+    </div>
+  )
+}
+
+function Th({ children, align = 'left', compact = false }: { children: React.ReactNode; align?: 'left' | 'right' | 'center'; compact?: boolean }) {
+  return (
+    <th style={{
+      textAlign: align,
+      padding: compact ? '10px 8px' : '12px 14px',
+      color: 'var(--text-secondary)',
+      fontSize: 10,
+      letterSpacing: '1px',
+      textTransform: 'uppercase',
+      fontWeight: 700,
+      whiteSpace: 'nowrap',
+    }}>
+      {children}
+    </th>
+  )
+}
+
+function Td({ children, align = 'left', compact = false }: { children: React.ReactNode; align?: 'left' | 'right' | 'center'; compact?: boolean }) {
+  return (
+    <td style={{
+      textAlign: align,
+      padding: compact ? '10px 8px' : '12px 14px',
+      verticalAlign: 'middle',
+    }}>
+      {children}
+    </td>
+  )
+}
+
+function MobileCards({ projects, loading, onOpen }: {
+  projects: ProjectRow[]
+  loading: boolean
+  onOpen: (slug: string) => void
+}) {
+  if (loading && projects.length === 0) {
+    return (
+      <div style={{
+        background: 'rgba(10, 22, 40, 0.55)',
+        border: '1px solid var(--input-border)',
+        borderRadius: 14,
+        padding: '32px 16px',
+        textAlign: 'center',
+        color: 'var(--text-muted)',
+        fontSize: 13,
+      }}>
+        ✦ Running checks…
+      </div>
+    )
+  }
+  if (!loading && projects.length === 0) {
+    return (
+      <div style={{
+        background: 'rgba(10, 22, 40, 0.55)',
+        border: '1px solid var(--input-border)',
+        borderRadius: 14,
+        padding: '32px 16px',
+        textAlign: 'center',
+        color: 'var(--text-muted)',
+        fontSize: 13,
+      }}>
+        No projects with inputs.md found under projects/
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {projects.map((p) => {
+        const tier = tierOf(p)
+        const c = STATE_COLORS[tier]
+        return (
+          <button
+            key={p.slug}
+            onClick={() => onOpen(p.slug)}
+            style={{
+              background: 'rgba(10, 22, 40, 0.55)',
+              border: '1px solid var(--input-border)',
+              borderRadius: 12,
+              padding: '14px 14px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+              cursor: 'pointer',
+              textAlign: 'left',
+              color: 'inherit',
+              fontFamily: 'inherit',
+              backdropFilter: 'blur(8px)',
+              width: '100%',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, width: '100%' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0, flex: 1 }}>
+                <span style={{
+                  color: 'var(--text-primary)',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  fontFamily: 'var(--font-body)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}>
+                  {p.slug}
+                </span>
+                {p.domain && (
+                  <span style={{
+                    color: 'var(--text-muted)',
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}>
+                    {p.domain}
+                  </span>
+                )}
+              </div>
+              <span style={{
+                background: c.bg,
+                border: `1px solid ${c.border}`,
+                color: c.fg,
+                padding: '5px 11px',
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 700,
+                fontVariantNumeric: 'tabular-nums',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}>
+                {p.passed} / {p.total}
+              </span>
+            </div>
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))',
+              gap: 6,
+            }}>
+              {p.groups.map((g) => {
+                const r = g.total > 0 ? g.passed / g.total : 0
+                const fg = g.total === 0 ? 'var(--text-muted)'
+                  : r >= 1 ? '#4ade80'
+                  : r >= 0.6 ? '#F9A96A'
+                  : '#f87171'
+                return (
+                  <div key={g.name} style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                    padding: '6px 8px',
+                    background: 'rgba(79, 195, 247, 0.04)',
+                    borderRadius: 6,
+                  }}>
+                    <span style={{
+                      color: 'var(--text-muted)',
+                      fontSize: 9,
+                      letterSpacing: '0.4px',
+                      textTransform: 'uppercase',
+                      fontWeight: 600,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}>
+                      {g.name}
+                    </span>
+                    <span style={{ color: fg, fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
+                      {g.total === 0 ? '—' : `${g.passed}/${g.total}`}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function GroupChip({ passed, total }: { passed: number; total: number }) {
+  if (total === 0) {
+    return <span style={{ color: 'var(--text-muted)', opacity: 0.4, fontSize: 11 }}>—</span>
+  }
+  const ratio = passed / total
+  const color = ratio >= 1
+    ? '#4ade80'
+    : ratio >= 0.6
+      ? '#F9A96A'
+      : '#f87171'
+  return (
+    <span style={{
+      color,
+      fontVariantNumeric: 'tabular-nums',
+      fontSize: 12,
+      fontWeight: 600,
+      fontFamily: 'var(--font-body)',
+    }}>
+      {passed}/{total}
+    </span>
+  )
+}

--- a/utopia-fairy/components/WishChecklist.tsx
+++ b/utopia-fairy/components/WishChecklist.tsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface CheckItem {
+  id: string
+  name: string
+  status: 'pass' | 'fail' | 'skip'
+  detail?: string
+}
+
+interface CheckGroup {
+  name: string
+  items: CheckItem[]
+}
+
+interface ChecklistData {
+  slug: string
+  domain: string | null
+  productSlug: string | null
+  deployUrl: string | null
+  passed: number
+  total: number
+  failedCount: number
+  groups: CheckGroup[]
+  ranAt: string
+}
+
+const COLORS = {
+  perfect: { bg: 'rgba(74, 222, 128, 0.12)', border: 'rgba(74, 222, 128, 0.35)', fg: '#4ade80' },
+  partial: { bg: 'rgba(249, 169, 106, 0.10)', border: 'rgba(249, 169, 106, 0.30)', fg: '#F9A96A' },
+  failing: { bg: 'rgba(248, 113, 113, 0.10)', border: 'rgba(248, 113, 113, 0.30)', fg: '#f87171' },
+  empty:   { bg: 'rgba(96, 112, 128, 0.08)', border: 'rgba(96, 112, 128, 0.25)', fg: '#7a8ea3' },
+} as const
+
+function tierOf(passed: number, total: number): keyof typeof COLORS {
+  if (total === 0) return 'empty'
+  const r = passed / total
+  if (r >= 1) return 'perfect'
+  if (r >= 0.6) return 'partial'
+  return 'failing'
+}
+
+export default function WishChecklist({ slug }: { slug: string }) {
+  const [data, setData] = useState<ChecklistData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/checklist/${slug}`, { cache: 'no-store' })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json: ChecklistData = await res.json()
+        if (mounted) { setData(json); setError(null) }
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : 'failed to load')
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    load()
+    const t = setInterval(load, 30_000)
+    return () => { mounted = false; clearInterval(t) }
+  }, [slug])
+
+  if (loading && !data) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 13, textAlign: 'center', padding: '24px 0' }}>
+        ✦ Running checklist…
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div style={{
+        background: 'rgba(248, 113, 113, 0.08)',
+        border: '1px solid rgba(248, 113, 113, 0.25)',
+        borderRadius: 10,
+        padding: '12px 16px',
+        color: '#f87171',
+        fontSize: 13,
+      }}>
+        Could not load checklist: {error ?? 'unknown error'}
+      </div>
+    )
+  }
+
+  const tier = tierOf(data.passed, data.total)
+  const c = COLORS[tier]
+  const failed = data.groups.flatMap((g) => g.items.filter((i) => i.status === 'fail').map((i) => ({ group: g.name, item: i })))
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20, width: '100%' }}>
+      {/* Score header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        gap: 12,
+        padding: '16px 20px',
+        borderRadius: 14,
+        background: c.bg,
+        border: `1px solid ${c.border}`,
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{
+            color: c.fg,
+            fontSize: 11,
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+          }}>
+            Checklist
+          </span>
+          <span style={{
+            color: 'var(--text-primary)',
+            fontSize: 15,
+            fontFamily: 'var(--font-body)',
+            fontWeight: 600,
+          }}>
+            {data.domain ?? data.slug}
+          </span>
+        </div>
+        <div style={{
+          color: c.fg,
+          fontSize: 28,
+          fontFamily: 'var(--font-body)',
+          fontWeight: 700,
+          fontVariantNumeric: 'tabular-nums',
+        }}>
+          {data.passed} <span style={{ opacity: 0.5, fontSize: 18 }}>/ {data.total}</span>
+        </div>
+      </div>
+
+      {/* Groups */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        {data.groups.map((g) => {
+          const passed = g.items.filter((i) => i.status === 'pass').length
+          const total = g.items.length
+          return (
+            <div key={g.name} style={{
+              background: 'rgba(10, 22, 40, 0.55)',
+              border: '1px solid var(--input-border)',
+              borderRadius: 12,
+              padding: '14px 16px',
+            }}>
+              <div style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: 10,
+              }}>
+                <span style={{
+                  color: 'var(--text-secondary)',
+                  fontSize: 11,
+                  letterSpacing: '1px',
+                  textTransform: 'uppercase',
+                  fontWeight: 700,
+                }}>
+                  {g.name}
+                </span>
+                <span style={{
+                  color: 'var(--text-muted)',
+                  fontSize: 12,
+                  fontFamily: 'var(--font-body)',
+                  fontWeight: 600,
+                  fontVariantNumeric: 'tabular-nums',
+                }}>
+                  {passed}/{total}
+                </span>
+              </div>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {g.items.map((i) => (
+                  <li key={i.id} style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 10,
+                    fontSize: 12.5,
+                    lineHeight: 1.5,
+                  }}>
+                    <StatusDot status={i.status} />
+                    <span style={{
+                      color: i.status === 'fail' ? '#f87171' : i.status === 'skip' ? 'var(--text-muted)' : 'var(--text-primary)',
+                      flex: 1,
+                    }}>
+                      {i.name}
+                      {i.detail && (
+                        <span style={{
+                          color: 'var(--text-muted)',
+                          fontSize: 11,
+                          opacity: 0.7,
+                          marginLeft: 6,
+                        }}>
+                          — {i.detail}
+                        </span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* To-implement list */}
+      {failed.length > 0 && (
+        <ToImplementSection slug={data.slug} failed={failed} />
+      )}
+    </div>
+  )
+}
+
+function buildSinglePrompt(slug: string, group: string, item: CheckItem): string {
+  return `Fix this checklist failure in projects/${slug}:
+
+[${group}] ${item.name}${item.detail ? `\nDetail: ${item.detail}` : ''}
+
+Reference docs/full-website-setup.md and CLAUDE.md (in repo root) for the canonical implementation pattern.`
+}
+
+function buildBatchPrompt(slug: string, failed: { group: string; item: CheckItem }[]): string {
+  const lines = failed.map((f, i) =>
+    `${i + 1}. [${f.group}] ${f.item.name}${f.item.detail ? `\n   ${f.item.detail}` : ''}`,
+  )
+  return `Fix the following checklist failures in projects/${slug}:
+
+${lines.join('\n')}
+
+Reference docs/full-website-setup.md and CLAUDE.md (in repo root) for the canonical implementation patterns. Work through each item, then re-run the monitor to confirm.`
+}
+
+function ToImplementSection({ slug, failed }: { slug: string; failed: { group: string; item: CheckItem }[] }) {
+  const [copiedAll, setCopiedAll] = useState(false)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const copyAll = async () => {
+    await navigator.clipboard.writeText(buildBatchPrompt(slug, failed))
+    setCopiedAll(true)
+    setTimeout(() => setCopiedAll(false), 1800)
+  }
+  const copyOne = async (id: string, group: string, item: CheckItem) => {
+    await navigator.clipboard.writeText(buildSinglePrompt(slug, group, item))
+    setCopiedId(id)
+    setTimeout(() => setCopiedId((c) => (c === id ? null : c)), 1800)
+  }
+
+  return (
+    <div style={{
+      background: 'rgba(248, 113, 113, 0.06)',
+      border: '1px solid rgba(248, 113, 113, 0.25)',
+      borderRadius: 12,
+      padding: '14px 16px',
+    }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 10,
+        flexWrap: 'wrap',
+        marginBottom: 10,
+      }}>
+        <span style={{
+          color: '#f87171',
+          fontSize: 11,
+          letterSpacing: '1px',
+          textTransform: 'uppercase',
+          fontWeight: 700,
+        }}>
+          To implement ({failed.length})
+        </span>
+        <button
+          onClick={copyAll}
+          style={{
+            background: copiedAll ? 'rgba(74, 222, 128, 0.15)' : 'rgba(248, 113, 113, 0.12)',
+            border: `1px solid ${copiedAll ? 'rgba(74, 222, 128, 0.4)' : 'rgba(248, 113, 113, 0.3)'}`,
+            borderRadius: 8,
+            padding: '6px 12px',
+            color: copiedAll ? '#4ade80' : '#f87171',
+            fontSize: 11,
+            fontWeight: 600,
+            cursor: 'pointer',
+            fontFamily: 'var(--font-body)',
+            letterSpacing: '0.3px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {copiedAll ? '✓ Copied' : '📋 Copy all as Claude prompt'}
+        </button>
+      </div>
+      <ol style={{ paddingLeft: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8, listStyle: 'none' }}>
+        {failed.map(({ group, item }, idx) => {
+          const just = copiedId === item.id
+          return (
+            <li key={item.id} style={{
+              color: 'var(--text-primary)',
+              fontSize: 13,
+              lineHeight: 1.5,
+              display: 'flex',
+              gap: 10,
+              alignItems: 'flex-start',
+            }}>
+              <span style={{
+                color: 'var(--text-muted)',
+                fontSize: 11,
+                fontVariantNumeric: 'tabular-nums',
+                paddingTop: 2,
+                minWidth: 18,
+              }}>{idx + 1}.</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ color: 'var(--text-secondary)', fontSize: 11, marginRight: 6 }}>[{group}]</span>
+                {item.name}
+                {item.detail && (
+                  <span style={{ color: 'var(--text-muted)', fontSize: 11, display: 'block', marginTop: 2 }}>
+                    {item.detail}
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => copyOne(item.id, group, item)}
+                title="Copy this item as a Claude prompt"
+                style={{
+                  background: just ? 'rgba(74, 222, 128, 0.15)' : 'transparent',
+                  border: `1px solid ${just ? 'rgba(74, 222, 128, 0.4)' : 'var(--input-border)'}`,
+                  borderRadius: 6,
+                  padding: '4px 8px',
+                  color: just ? '#4ade80' : 'var(--text-muted)',
+                  fontSize: 10,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  fontFamily: 'var(--font-body)',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                }}
+              >
+                {just ? '✓ copied' : 'copy'}
+              </button>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}
+
+function StatusDot({ status }: { status: 'pass' | 'fail' | 'skip' }) {
+  const color = status === 'pass' ? '#4ade80' : status === 'fail' ? '#f87171' : '#7a8ea3'
+  const glyph = status === 'pass' ? '✓' : status === 'fail' ? '✕' : '–'
+  return (
+    <span style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: 16,
+      height: 16,
+      borderRadius: '50%',
+      background: status === 'pass' ? 'rgba(74, 222, 128, 0.15)' : status === 'fail' ? 'rgba(248, 113, 113, 0.15)' : 'rgba(96, 112, 128, 0.15)',
+      color,
+      fontSize: 10,
+      fontWeight: 700,
+      flexShrink: 0,
+      marginTop: 2,
+    }}>
+      {glyph}
+    </span>
+  )
+}

--- a/utopia-fairy/components/WishData.tsx
+++ b/utopia-fairy/components/WishData.tsx
@@ -1,0 +1,722 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface PhoneRow {
+  phone_number: string
+  label: string | null
+  location_slug: string | null
+  whatsapp_text: string | null
+  percentage: number | null
+  type: string | null
+  is_active: boolean
+}
+
+interface ProductRow {
+  name: string
+  slug: string
+  description: string | null
+  sale_price: number | null
+  rental_price: number | null
+  sort_order: number | null
+  is_active: boolean
+  product_photos: { url: string }[]
+}
+
+interface BlogRow {
+  slug: string
+  status: string
+  cover_image_url: string | null
+  blog_translations: { language: string; title: string | null }[]
+}
+
+interface RegisteredDomain {
+  domain: string
+  leads_mode: string | null
+  company_id: string | null
+}
+
+interface HardcodedHit {
+  file: string
+  line: number
+  match: string
+  excerpt: string
+}
+
+interface BlogHardcodedHit {
+  post_slug: string
+  language: string
+  field: string
+  match: string
+  excerpt: string
+}
+
+interface LiveStatus {
+  status: 'connected' | 'fallback' | 'unexpected' | 'no-target' | 'no-response'
+  targetUrl: string | null
+  livePhone: string | null
+  dbPhones: string[]
+  fallbackPhone: string | null
+  detail: string
+}
+
+interface WishDataPayload {
+  slug: string
+  domain: string | null
+  fallbackPhone: string | null
+  domainCandidates: string[]
+  registered: RegisteredDomain[] | null
+  phones: PhoneRow[] | null
+  products: ProductRow[] | null
+  blogs: BlogRow[] | null
+  hardcoded: HardcodedHit[]
+  blogHardcoded: BlogHardcodedHit[]
+  liveStatus: LiveStatus
+}
+
+export default function WishData({ slug }: { slug: string }) {
+  const [data, setData] = useState<WishDataPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/wish-data/${slug}`, { cache: 'no-store' })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json: WishDataPayload = await res.json()
+        if (mounted) { setData(json); setError(null) }
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : 'failed to load')
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    load()
+    const t = setInterval(load, 60_000)
+    return () => { mounted = false; clearInterval(t) }
+  }, [slug])
+
+  if (loading && !data) {
+    return <Stub>✦ Loading registered data…</Stub>
+  }
+  if (error || !data) {
+    return <ErrorBox>Could not load: {error ?? 'unknown error'}</ErrorBox>
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: '100%' }}>
+      <LiveStatusBanner s={data.liveStatus} />
+      <RegisteredSection data={data} />
+      <PhonesSection rows={data.phones} />
+      <ProductsSection rows={data.products} />
+      <BlogsSection rows={data.blogs} />
+      <HardcodedSection hits={data.hardcoded} />
+      <BlogHardcodedSection hits={data.blogHardcoded} />
+    </div>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Live DB connectivity banner — is the deployed site reading from Supabase?
+// ────────────────────────────────────────────────────────────────────────────
+
+function LiveStatusBanner({ s }: { s: LiveStatus }) {
+  const palette = {
+    connected:  { bg: 'rgba(74, 222, 128, 0.10)', border: 'rgba(74, 222, 128, 0.35)', fg: '#4ade80', label: 'Live · DB connected', dot: '#4ade80' },
+    fallback:   { bg: 'rgba(249, 169, 106, 0.10)', border: 'rgba(249, 169, 106, 0.35)', fg: '#F9A96A', label: 'Live · using fallback', dot: '#F9A96A' },
+    unexpected: { bg: 'rgba(248, 113, 113, 0.10)', border: 'rgba(248, 113, 113, 0.35)', fg: '#f87171', label: 'Live · phone mismatch',  dot: '#f87171' },
+    'no-response': { bg: 'rgba(248, 113, 113, 0.08)', border: 'rgba(248, 113, 113, 0.25)', fg: '#f87171', label: 'Live · no response', dot: '#f87171' },
+    'no-target': { bg: 'rgba(96, 112, 128, 0.10)', border: 'rgba(96, 112, 128, 0.30)', fg: '#7a8ea3', label: 'Live · not deployed', dot: '#7a8ea3' },
+  }[s.status]
+
+  return (
+    <section style={{
+      background: palette.bg,
+      border: `1px solid ${palette.border}`,
+      borderRadius: 14,
+      padding: '16px 20px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 10,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{
+            width: 10, height: 10, borderRadius: '50%',
+            background: palette.dot,
+            boxShadow: s.status === 'connected' ? `0 0 10px ${palette.dot}` : 'none',
+          }} />
+          <span style={{
+            color: palette.fg,
+            fontSize: 12,
+            letterSpacing: '1.4px',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            fontFamily: 'var(--font-body)',
+          }}>
+            {palette.label}
+          </span>
+        </div>
+        {s.targetUrl && (
+          <a
+            href={s.targetUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--text-muted)', fontSize: 11, fontFamily: 'monospace', textDecoration: 'underline' }}
+          >
+            probed: {s.targetUrl.replace(/^https?:\/\//, '')}
+          </a>
+        )}
+      </div>
+
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+        gap: 12,
+        marginTop: 4,
+      }}>
+        <Stat label="Live phone" value={s.livePhone ?? '—'} accent={palette.fg} />
+        <Stat label="DB phone(s)" value={s.dbPhones.length === 0 ? '—' : s.dbPhones.join(', ')} />
+        <Stat label="Fallback (config/site.ts)" value={s.fallbackPhone ?? '—'} />
+      </div>
+
+      <p style={{
+        color: 'var(--text-primary)',
+        fontSize: 12,
+        lineHeight: 1.55,
+        fontFamily: 'var(--font-body)',
+        margin: 0,
+        opacity: 0.9,
+      }}>
+        {s.detail}
+      </p>
+
+      {s.status === 'fallback' && (
+        <p style={{
+          color: palette.fg,
+          fontSize: 11,
+          lineHeight: 1.5,
+          fontFamily: 'var(--font-body)',
+          margin: 0,
+        }}>
+          Fix: confirm <code>NEXT_PUBLIC_SUPABASE_URL</code> + <code>NEXT_PUBLIC_SUPABASE_ANON_KEY</code> are set on this Vercel project, then redeploy. If env was already set, fire the webcore revalidate webhook to flush stale cache.
+        </p>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={{ color: 'var(--text-muted)', fontSize: 10, letterSpacing: '0.6px', textTransform: 'uppercase', fontWeight: 600 }}>
+        {label}
+      </span>
+      <code style={{
+        color: accent ?? 'var(--text-primary)',
+        fontSize: 13,
+        fontFamily: 'monospace',
+        wordBreak: 'break-word',
+        fontWeight: accent ? 700 : 400,
+      }}>
+        {value}
+      </code>
+    </div>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Registered domains (catches sites that have moved to a new domain)
+// ────────────────────────────────────────────────────────────────────────────
+
+function RegisteredSection({ data }: { data: WishDataPayload }) {
+  const reg = data.registered ?? []
+  const expected = data.domain
+  const newDomains = reg.filter((r) => r.domain !== expected)
+
+  return (
+    <Card title="Registered Domains" subtitle="company_websites rows matched to this project" count={reg.length}>
+      {reg.length === 0 ? (
+        <Empty>No row in company_websites for any candidate domain. The site may not be registered yet, or it lives under a custom domain that we couldn't auto-discover.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Domain</Th>
+              <Th>Leads mode</Th>
+              <Th>Status</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {reg.map((r) => {
+              const moved = expected && r.domain !== expected
+              return (
+                <tr key={r.domain} style={rowStyle}>
+                  <Td>
+                    <code style={{ color: 'var(--accent-fairy)', fontSize: 12 }}>{r.domain}</code>
+                  </Td>
+                  <Td>
+                    <Pill>{r.leads_mode ?? '—'}</Pill>
+                  </Td>
+                  <Td>
+                    {moved
+                      ? <Pill tone="warn">moved from {expected}</Pill>
+                      : <Pill tone="good">matches config/site.ts</Pill>}
+                  </Td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+      {newDomains.length > 0 && (
+        <p style={{ color: '#F9A96A', fontSize: 12, marginTop: 8, fontFamily: 'var(--font-body)' }}>
+          Heads up — this project is registered under {newDomains.length === 1 ? 'a domain' : `${newDomains.length} domains`} that don't match config/site.ts (
+          {newDomains.map((d) => d.domain).join(', ')}
+          ). Update config/site.ts.domain if it has officially moved.
+        </p>
+      )}
+      <p style={{ color: 'var(--text-muted)', fontSize: 11, marginTop: 6, opacity: 0.6 }}>
+        Looked up by: {data.domainCandidates.join(' · ')}
+      </p>
+    </Card>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Phone numbers (with WhatsApp text)
+// ────────────────────────────────────────────────────────────────────────────
+
+function PhonesSection({ rows }: { rows: PhoneRow[] | null }) {
+  if (rows == null) return <Card title="Phone Numbers" count={0}><Empty>Supabase query failed.</Empty></Card>
+  return (
+    <Card title="Phone Numbers" subtitle="phone_numbers rows for this site" count={rows.length}>
+      {rows.length === 0 ? (
+        <Empty>No phone numbers seeded for this site yet.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Number</Th>
+              <Th>Label</Th>
+              <Th>Location</Th>
+              <Th>%</Th>
+              <Th>Active</Th>
+              <Th>WhatsApp text</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} style={rowStyle}>
+                <Td>
+                  <code style={{ color: 'var(--accent-fairy)', fontSize: 12 }}>{r.phone_number}</code>
+                  {r.type && <span style={{ color: 'var(--text-muted)', fontSize: 10, marginLeft: 6 }}>({r.type})</span>}
+                </Td>
+                <Td><span style={{ color: 'var(--text-primary)', fontSize: 12 }}>{r.label ?? '—'}</span></Td>
+                <Td><code style={{ color: 'var(--text-muted)', fontSize: 11 }}>{r.location_slug ?? '—'}</code></Td>
+                <Td><span style={{ color: 'var(--text-muted)', fontSize: 12 }}>{r.percentage ?? '—'}</span></Td>
+                <Td>{r.is_active ? <Pill tone="good">on</Pill> : <Pill tone="warn">off</Pill>}</Td>
+                <Td>
+                  <div style={{
+                    color: 'var(--text-primary)',
+                    fontSize: 11,
+                    lineHeight: 1.4,
+                    maxWidth: 360,
+                    fontFamily: 'var(--font-body)',
+                    whiteSpace: 'pre-wrap',
+                  }}>
+                    {r.whatsapp_text ?? <span style={{ color: 'var(--text-muted)', opacity: 0.6 }}>—</span>}
+                  </div>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Products
+// ────────────────────────────────────────────────────────────────────────────
+
+function ProductsSection({ rows }: { rows: ProductRow[] | null }) {
+  if (rows == null) return <Card title="Products" count={0}><Empty>Supabase query failed.</Empty></Card>
+  const active = rows.filter((r) => r.is_active).length
+  return (
+    <Card
+      title="Products"
+      subtitle={`${active} active · ${rows.length} total`}
+      count={rows.length}
+    >
+      {rows.length === 0 ? (
+        <Empty>No products in Supabase for this site yet.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Photo</Th>
+              <Th>Name</Th>
+              <Th>Slug</Th>
+              <Th>Sale</Th>
+              <Th>Rental</Th>
+              <Th>Order</Th>
+              <Th>Active</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const photo = r.product_photos?.[0]?.url
+              return (
+                <tr key={r.slug} style={rowStyle}>
+                  <Td>
+                    {photo ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={photo} alt={r.name} style={{
+                        width: 40, height: 40, objectFit: 'cover', borderRadius: 6,
+                        border: '1px solid var(--input-border)',
+                      }} />
+                    ) : (
+                      <div style={{ width: 40, height: 40, borderRadius: 6, background: 'rgba(96, 112, 128, 0.15)' }} />
+                    )}
+                  </Td>
+                  <Td><span style={{ color: 'var(--text-primary)', fontSize: 12, fontWeight: 600 }}>{r.name}</span></Td>
+                  <Td><code style={{ color: 'var(--accent-fairy)', fontSize: 11 }}>{r.slug}</code></Td>
+                  <Td><Price v={r.sale_price} /></Td>
+                  <Td><Price v={r.rental_price} /></Td>
+                  <Td><span style={{ color: 'var(--text-muted)', fontSize: 12 }}>{r.sort_order ?? '—'}</span></Td>
+                  <Td>{r.is_active ? <Pill tone="good">on</Pill> : <Pill tone="warn">off</Pill>}</Td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  )
+}
+
+function Price({ v }: { v: number | null }) {
+  if (v == null) return <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>—</span>
+  return <span style={{ color: 'var(--text-primary)', fontSize: 12, fontVariantNumeric: 'tabular-nums' }}>RM {v.toLocaleString('en-MY')}</span>
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Blog articles
+// ────────────────────────────────────────────────────────────────────────────
+
+function BlogsSection({ rows }: { rows: BlogRow[] | null }) {
+  if (rows == null) return <Card title="Blog Articles" count={0}><Empty>Supabase query failed.</Empty></Card>
+  const published = rows.filter((r) => r.status === 'published').length
+  return (
+    <Card
+      title="Blog Articles"
+      subtitle={`${published} published · ${rows.length} total`}
+      count={rows.length}
+    >
+      {rows.length === 0 ? (
+        <Empty>No blog posts in Supabase for this site yet.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Cover</Th>
+              <Th>Title (en)</Th>
+              <Th>Slug</Th>
+              <Th>Locales</Th>
+              <Th>Status</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const en = r.blog_translations?.find((t) => t.language === 'en')
+              const title = en?.title ?? r.blog_translations?.[0]?.title ?? r.slug
+              const locales = (r.blog_translations ?? []).map((t) => t.language).sort().join(' · ')
+              return (
+                <tr key={r.slug} style={rowStyle}>
+                  <Td>
+                    {r.cover_image_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={r.cover_image_url} alt={title} style={{
+                        width: 56, height: 36, objectFit: 'cover', borderRadius: 4,
+                        border: '1px solid var(--input-border)',
+                      }} />
+                    ) : (
+                      <div style={{ width: 56, height: 36, borderRadius: 4, background: 'rgba(96, 112, 128, 0.15)' }} />
+                    )}
+                  </Td>
+                  <Td>
+                    <span style={{ color: 'var(--text-primary)', fontSize: 12, fontWeight: 500, lineHeight: 1.4, maxWidth: 320, display: 'inline-block' }}>{title}</span>
+                  </Td>
+                  <Td><code style={{ color: 'var(--accent-fairy)', fontSize: 11 }}>{r.slug}</code></Td>
+                  <Td><span style={{ color: 'var(--text-muted)', fontSize: 11, fontFamily: 'monospace' }}>{locales || '—'}</span></Td>
+                  <Td>
+                    {r.status === 'published'
+                      ? <Pill tone="good">published</Pill>
+                      : <Pill tone="warn">{r.status}</Pill>}
+                  </Td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hardcoded phones (source scan)
+// ────────────────────────────────────────────────────────────────────────────
+
+function HardcodedSection({ hits }: { hits: HardcodedHit[] }) {
+  return (
+    <Card
+      title="Hardcoded Phone Numbers"
+      subtitle="grep across app/ and components/"
+      count={hits.length}
+      tone={hits.length === 0 ? 'good' : 'warn'}
+    >
+      {hits.length === 0 ? (
+        <Empty tone="good">Clean — no phone numbers found in any user-facing source file.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Location</Th>
+              <Th>Number</Th>
+              <Th>Line</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {hits.map((h, i) => (
+              <tr key={i} style={rowStyle}>
+                <Td>
+                  <code style={{ color: 'var(--accent-fairy)', fontSize: 11 }}>{h.file}:{h.line}</code>
+                </Td>
+                <Td>
+                  <code style={{ color: '#f87171', fontSize: 12, fontWeight: 600 }}>{h.match}</code>
+                </Td>
+                <Td>
+                  <code style={{ color: 'var(--text-muted)', fontSize: 11, fontFamily: 'monospace', display: 'block', maxWidth: 460, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                    {h.excerpt}
+                  </code>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hardcoded phones in blog content (Supabase blog_translations)
+// ────────────────────────────────────────────────────────────────────────────
+
+function BlogHardcodedSection({ hits }: { hits: BlogHardcodedHit[] }) {
+  return (
+    <Card
+      title="Hardcoded Phones in Blog Articles"
+      subtitle="scan across blog_translations title / content / excerpt / meta"
+      count={hits.length}
+      tone={hits.length === 0 ? 'good' : 'warn'}
+    >
+      {hits.length === 0 ? (
+        <Empty tone="good">Clean — no phone numbers found inside any blog post.</Empty>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <Th>Post · lang</Th>
+              <Th>Field</Th>
+              <Th>Number</Th>
+              <Th>Context</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {hits.map((h, i) => (
+              <tr key={i} style={rowStyle}>
+                <Td>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <code style={{ color: 'var(--accent-fairy)', fontSize: 11 }}>{h.post_slug}</code>
+                    <Pill>{h.language}</Pill>
+                  </div>
+                </Td>
+                <Td>
+                  <code style={{ color: 'var(--text-muted)', fontSize: 11 }}>{h.field}</code>
+                </Td>
+                <Td>
+                  <code style={{ color: '#f87171', fontSize: 12, fontWeight: 600 }}>{h.match}</code>
+                </Td>
+                <Td>
+                  <code style={{ color: 'var(--text-muted)', fontSize: 11, fontFamily: 'monospace', display: 'block', maxWidth: 460, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                    {h.excerpt}
+                  </code>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Reusable bits
+// ────────────────────────────────────────────────────────────────────────────
+
+function Card({ title, subtitle, count, tone, children }: {
+  title: string
+  subtitle?: string
+  count: number
+  tone?: 'good' | 'warn'
+  children: React.ReactNode
+}) {
+  const accent = tone === 'good' ? '#4ade80'
+    : tone === 'warn' ? '#F9A96A'
+    : 'var(--text-secondary)'
+  return (
+    <section style={{
+      background: 'rgba(10, 22, 40, 0.55)',
+      border: '1px solid var(--input-border)',
+      borderRadius: 12,
+      padding: '14px 16px',
+    }}>
+      <header style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 10, gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{
+            color: accent,
+            fontSize: 11,
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            fontFamily: 'var(--font-body)',
+          }}>
+            {title}
+          </span>
+          {subtitle && (
+            <span style={{ color: 'var(--text-muted)', fontSize: 11, fontFamily: 'var(--font-body)' }}>
+              {subtitle}
+            </span>
+          )}
+        </div>
+        <span style={{
+          color: 'var(--text-secondary)',
+          fontSize: 12,
+          fontFamily: 'var(--font-body)',
+          fontWeight: 600,
+          fontVariantNumeric: 'tabular-nums',
+        }}>
+          {count}
+        </span>
+      </header>
+      <div style={{ overflowX: 'auto' }}>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function Empty({ children, tone }: { children: React.ReactNode; tone?: 'good' }) {
+  return (
+    <p style={{
+      color: tone === 'good' ? '#4ade80' : 'var(--text-muted)',
+      fontSize: 12,
+      fontFamily: 'var(--font-body)',
+      opacity: 0.85,
+      margin: '4px 0 0',
+    }}>
+      {children}
+    </p>
+  )
+}
+
+function Pill({ children, tone }: { children: React.ReactNode; tone?: 'good' | 'warn' }) {
+  const fg = tone === 'good' ? '#4ade80' : tone === 'warn' ? '#F9A96A' : 'var(--text-muted)'
+  const bg = tone === 'good' ? 'rgba(74, 222, 128, 0.12)' : tone === 'warn' ? 'rgba(249, 169, 106, 0.12)' : 'rgba(96, 112, 128, 0.12)'
+  return (
+    <span style={{
+      color: fg,
+      background: bg,
+      padding: '2px 8px',
+      borderRadius: 999,
+      fontSize: 10,
+      fontWeight: 600,
+      letterSpacing: '0.3px',
+      fontFamily: 'var(--font-body)',
+      whiteSpace: 'nowrap',
+      display: 'inline-block',
+    }}>
+      {children}
+    </span>
+  )
+}
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 12,
+  fontFamily: 'var(--font-body)',
+}
+
+const rowStyle: React.CSSProperties = {
+  borderTop: '1px solid var(--input-border)',
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th style={{
+      textAlign: 'left',
+      padding: '8px 10px',
+      color: 'var(--text-secondary)',
+      fontSize: 10,
+      letterSpacing: '0.8px',
+      textTransform: 'uppercase',
+      fontWeight: 700,
+      whiteSpace: 'nowrap',
+      borderBottom: '1px solid var(--input-border)',
+    }}>
+      {children}
+    </th>
+  )
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return (
+    <td style={{
+      padding: '8px 10px',
+      verticalAlign: 'top',
+    }}>
+      {children}
+    </td>
+  )
+}
+
+function Stub({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ color: 'var(--text-muted)', fontSize: 13, textAlign: 'center', padding: '24px 0' }}>
+      {children}
+    </div>
+  )
+}
+
+function ErrorBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{
+      background: 'rgba(248, 113, 113, 0.08)',
+      border: '1px solid rgba(248, 113, 113, 0.25)',
+      borderRadius: 10,
+      padding: '12px 16px',
+      color: '#f87171',
+      fontSize: 13,
+    }}>
+      {children}
+    </div>
+  )
+}

--- a/utopia-fairy/components/WishHistory.tsx
+++ b/utopia-fairy/components/WishHistory.tsx
@@ -238,7 +238,7 @@ export default function WishHistory() {
           borderTop: '1px solid var(--input-border)',
         }}>
           <button
-            onClick={() => { router.push('/'); setOpen(false) }}
+            onClick={() => { router.push('/new'); setOpen(false) }}
             style={{
               width: '100%',
               background: 'linear-gradient(135deg, var(--accent-deep), var(--accent-glow))',

--- a/utopia-fairy/lib/checklist.ts
+++ b/utopia-fairy/lib/checklist.ts
@@ -1,0 +1,558 @@
+import { readFile, access, readdir } from 'fs/promises'
+import path from 'path'
+import type { ProjectInfo } from './projectInfo'
+import { getDomainCounts, getBlogContentRows, getPhoneRows, getRegisteredDomains, supabaseConfigured } from './supabaseChecks'
+import { findHardcodedPhones, findBlogHardcodedPhones } from './sourceScan'
+import { checkLiveDbConnection } from './liveStatusCheck'
+
+export type CheckStatus = 'pass' | 'fail' | 'skip'
+
+export interface CheckResult {
+  id: string
+  name: string
+  status: CheckStatus
+  detail?: string
+}
+
+export interface CheckGroup {
+  name: string
+  items: CheckResult[]
+}
+
+interface Ctx {
+  info: ProjectInfo
+  fileCache: Map<string, string | null>
+  grepCache: Map<string, boolean>
+}
+
+async function readProjectFile(ctx: Ctx, rel: string): Promise<string | null> {
+  if (ctx.fileCache.has(rel)) return ctx.fileCache.get(rel)!
+  try {
+    const content = await readFile(path.join(ctx.info.projectDir, rel), 'utf-8')
+    ctx.fileCache.set(rel, content)
+    return content
+  } catch {
+    ctx.fileCache.set(rel, null)
+    return null
+  }
+}
+
+async function fileExists(ctx: Ctx, rel: string): Promise<boolean> {
+  try {
+    await access(path.join(ctx.info.projectDir, rel))
+    return true
+  } catch {
+    return false
+  }
+}
+
+const SKIP_DIRS = new Set(['node_modules', '.next', '.vercel', '.git', 'temporary screenshots', 'brand_assets'])
+
+async function grepProject(ctx: Ctx, pattern: RegExp, exts: string[] = ['.tsx', '.ts']): Promise<boolean> {
+  const key = `${pattern.source}|${exts.join(',')}`
+  if (ctx.grepCache.has(key)) return ctx.grepCache.get(key)!
+
+  const walk = async (dir: string): Promise<boolean> => {
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+      return false
+    }
+    for (const e of entries) {
+      if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue
+      const p = path.join(dir, e.name)
+      if (e.isDirectory()) {
+        if (await walk(p)) return true
+      } else if (exts.some((x) => e.name.endsWith(x))) {
+        try {
+          const c = await readFile(p, 'utf-8')
+          if (pattern.test(c)) return true
+        } catch { /* skip unreadable */ }
+      }
+    }
+    return false
+  }
+
+  const found = await walk(ctx.info.projectDir)
+  ctx.grepCache.set(key, found)
+  return found
+}
+
+async function dirHasFiles(ctx: Ctx, rel: string, exts: string[]): Promise<boolean> {
+  try {
+    const entries = await readdir(path.join(ctx.info.projectDir, rel))
+    return entries.some((f) => exts.some((x) => f.endsWith(x)))
+  } catch {
+    return false
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Check definitions
+// ────────────────────────────────────────────────────────────────────────────
+
+type Check = {
+  group: string
+  id: string
+  name: string
+  run: (ctx: Ctx) => Promise<CheckResult>
+}
+
+const pass = (id: string, name: string, detail?: string): CheckResult => ({ id, name, status: 'pass', detail })
+const fail = (id: string, name: string, detail?: string): CheckResult => ({ id, name, status: 'fail', detail })
+const skip = (id: string, name: string, detail?: string): CheckResult => ({ id, name, status: 'skip', detail })
+
+const STRUCTURE: Check[] = [
+  {
+    group: 'Structure', id: 'homepage', name: 'Homepage exists',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/[locale]/page.tsx')
+      return ok
+        ? pass('homepage', 'Homepage exists', 'app/[locale]/page.tsx')
+        : fail('homepage', 'Homepage exists', 'Missing app/[locale]/page.tsx')
+    },
+  },
+  {
+    group: 'Structure', id: 'location-page', name: 'Location pages exist',
+    run: async (ctx) => {
+      const slug = ctx.info.productSlug
+      if (!slug) return skip('location-page', 'Location pages exist', 'Unknown productSlug — cannot infer route')
+      const p = `app/[locale]/${slug}/[location]/page.tsx`
+      const ok = await fileExists(ctx, p)
+      return ok
+        ? pass('location-page', 'Location pages exist', p)
+        : fail('location-page', 'Location pages exist', `Missing ${p}`)
+    },
+  },
+  {
+    group: 'Structure', id: 'blog-listing', name: 'Blog listing page',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/[locale]/blog/page.tsx')
+      return ok
+        ? pass('blog-listing', 'Blog listing page', 'app/[locale]/blog/page.tsx')
+        : fail('blog-listing', 'Blog listing page', 'Missing app/[locale]/blog/page.tsx')
+    },
+  },
+  {
+    group: 'Structure', id: 'blog-post', name: 'Blog post detail page',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/[locale]/blog/[slug]/page.tsx')
+      return ok
+        ? pass('blog-post', 'Blog post detail page', 'app/[locale]/blog/[slug]/page.tsx')
+        : fail('blog-post', 'Blog post detail page', 'Missing app/[locale]/blog/[slug]/page.tsx')
+    },
+  },
+  {
+    group: 'Structure', id: 'whatsapp-redirect', name: 'WhatsApp redirect page',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/[locale]/redirect-whatsapp-1/page.tsx')
+      return ok
+        ? pass('whatsapp-redirect', 'WhatsApp redirect page', 'app/[locale]/redirect-whatsapp-1/page.tsx')
+        : fail('whatsapp-redirect', 'WhatsApp redirect page', 'Missing app/[locale]/redirect-whatsapp-1/page.tsx')
+    },
+  },
+]
+
+const SEO: Check[] = [
+  {
+    group: 'SEO', id: 'sitemap', name: 'Sitemap generator',
+    run: async (ctx) => {
+      const a = await fileExists(ctx, 'app/sitemap.ts')
+      const b = await fileExists(ctx, 'app/sitemap.xml/route.ts')
+      return (a || b)
+        ? pass('sitemap', 'Sitemap generator')
+        : fail('sitemap', 'Sitemap generator', 'Missing app/sitemap.ts')
+    },
+  },
+  {
+    group: 'SEO', id: 'robots', name: 'robots.txt generator',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/robots.ts')
+      return ok
+        ? pass('robots', 'robots.txt generator')
+        : fail('robots', 'robots.txt generator', 'Missing app/robots.ts')
+    },
+  },
+  {
+    group: 'SEO', id: 'schema-components', name: 'Schema markup components',
+    run: async (ctx) => {
+      const ok = await dirHasFiles(ctx, 'components/schema', ['.tsx', '.ts'])
+      return ok
+        ? pass('schema-components', 'Schema markup components', 'components/schema/*')
+        : fail('schema-components', 'Schema markup components', 'Missing components/schema/*.tsx')
+    },
+  },
+  {
+    group: 'SEO', id: 'homepage-metadata', name: 'Homepage exports metadata',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'app/[locale]/page.tsx')
+      if (!c) return fail('homepage-metadata', 'Homepage exports metadata', 'Homepage file missing')
+      const ok = /export\s+(const|async function)\s+(metadata|generateMetadata)/.test(c)
+      return ok
+        ? pass('homepage-metadata', 'Homepage exports metadata')
+        : fail('homepage-metadata', 'Homepage exports metadata', 'No metadata/generateMetadata export in homepage')
+    },
+  },
+]
+
+const I18N: Check[] = [
+  {
+    group: 'i18n', id: 'i18n-routing', name: 'i18n routing config',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'i18n/routing.ts')
+      return ok
+        ? pass('i18n-routing', 'i18n routing config')
+        : fail('i18n-routing', 'i18n routing config', 'Missing i18n/routing.ts')
+    },
+  },
+  {
+    group: 'i18n', id: 'middleware', name: 'next-intl middleware',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'middleware.ts')
+      return ok
+        ? pass('middleware', 'next-intl middleware')
+        : fail('middleware', 'next-intl middleware', 'Missing middleware.ts')
+    },
+  },
+  {
+    group: 'i18n', id: 'translations', name: 'Translation files (en/ms/zh)',
+    run: async (ctx) => {
+      const en = await fileExists(ctx, 'messages/en.json')
+      const ms = await fileExists(ctx, 'messages/ms.json')
+      const zh = await fileExists(ctx, 'messages/zh.json')
+      const have = [en && 'en', ms && 'ms', zh && 'zh'].filter(Boolean) as string[]
+      if (have.length === 3) return pass('translations', 'Translation files (en/ms/zh)', 'all 3 locales present')
+      if (have.length === 0) return fail('translations', 'Translation files (en/ms/zh)', 'no messages/*.json found')
+      return fail('translations', 'Translation files (en/ms/zh)', `only ${have.join(', ')}`)
+    },
+  },
+  {
+    group: 'i18n', id: 'language-switcher', name: 'Language switcher component',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'components/LanguageSwitcher.tsx')
+      return ok
+        ? pass('language-switcher', 'Language switcher component')
+        : fail('language-switcher', 'Language switcher component', 'Missing components/LanguageSwitcher.tsx')
+    },
+  },
+]
+
+const WEBCORE: Check[] = [
+  {
+    group: 'Webcore data layer', id: 'webcore-lib', name: 'lib/webcore.ts exists',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'lib/webcore.ts')
+      return ok
+        ? pass('webcore-lib', 'lib/webcore.ts exists')
+        : fail('webcore-lib', 'lib/webcore.ts exists', 'Missing lib/webcore.ts — site is not on the cache-tag data layer')
+    },
+  },
+  {
+    group: 'Webcore data layer', id: 'revalidate-route', name: '/api/revalidate route',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/api/revalidate/route.ts')
+      return ok
+        ? pass('revalidate-route', '/api/revalidate route')
+        : fail('revalidate-route', '/api/revalidate route', 'Missing app/api/revalidate/route.ts')
+    },
+  },
+  {
+    group: 'Webcore data layer', id: 'no-forbidden-libs', name: 'No forbidden lib/* files',
+    run: async (ctx) => {
+      const forbidden = ['lib/supabase.ts', 'lib/getProducts.ts', 'lib/getPhoneNumber.ts', 'lib/getBlogPosts.ts']
+      const found: string[] = []
+      for (const f of forbidden) {
+        if (await fileExists(ctx, f)) found.push(f)
+      }
+      return found.length === 0
+        ? pass('no-forbidden-libs', 'No forbidden lib/* files')
+        : fail('no-forbidden-libs', 'No forbidden lib/* files', `forbidden: ${found.join(', ')}`)
+    },
+  },
+  {
+    group: 'Webcore data layer', id: 'no-time-revalidate', name: 'No time-based ISR (export const revalidate = N)',
+    run: async (ctx) => {
+      const bad = await grepProject(ctx, /export\s+const\s+revalidate\s*=\s*[1-9]/)
+      return bad
+        ? fail('no-time-revalidate', 'No time-based ISR (export const revalidate = N)', 'found `export const revalidate = N` somewhere — must use tag-based invalidation')
+        : pass('no-time-revalidate', 'No time-based ISR (export const revalidate = N)')
+    },
+  },
+]
+
+const TRACKING: Check[] = [
+  {
+    group: 'Tracking', id: 'tracking-script', name: 'Tracking script in layout',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'app/[locale]/layout.tsx')
+      if (!c) return fail('tracking-script', 'Tracking script in layout', 'layout.tsx missing')
+      const ok = /webcore\.utopiaai\.my\/t\.js/.test(c)
+      return ok
+        ? pass('tracking-script', 'Tracking script in layout')
+        : fail('tracking-script', 'Tracking script in layout', 'no webcore.utopiaai.my/t.js script tag')
+    },
+  },
+  {
+    group: 'Tracking', id: 'data-website-match', name: 'data-website matches domain',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'app/[locale]/layout.tsx')
+      if (!c) return fail('data-website-match', 'data-website matches domain', 'layout.tsx missing')
+      const m = c.match(/data-website=["']([^"']+)["']/)
+      if (!m) return fail('data-website-match', 'data-website matches domain', 'no data-website attribute on tracking script')
+      const dw = m[1]
+      // Accept either the vercel domain or the *.utopiaai.my alias
+      const domain = ctx.info.domain
+      if (!domain) return skip('data-website-match', 'data-website matches domain', `data-website=${dw} but project domain unknown`)
+      const alias = domain.replace(/\.vercel\.app$/, '.utopiaai.my')
+      const ok = dw === domain || dw === alias
+      return ok
+        ? pass('data-website-match', 'data-website matches domain', dw)
+        : fail('data-website-match', 'data-website matches domain', `data-website=${dw}, expected ${domain} or ${alias}`)
+    },
+  },
+  {
+    group: 'Tracking', id: 'uwc-typedef', name: 'window.uwc type declaration',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'global.d.ts')
+      if (!c) return fail('uwc-typedef', 'window.uwc type declaration', 'global.d.ts missing')
+      const ok = /uwc\s*:/.test(c)
+      return ok
+        ? pass('uwc-typedef', 'window.uwc type declaration')
+        : fail('uwc-typedef', 'window.uwc type declaration', 'no uwc declaration in global.d.ts')
+    },
+  },
+  {
+    group: 'Tracking', id: 'whatsapp-click-track', name: 'WhatsApp click tracked',
+    run: async (ctx) => {
+      const ok = await grepProject(ctx, /uwc\(['"]click['"][^)]*whatsapp-/)
+      return ok
+        ? pass('whatsapp-click-track', 'WhatsApp click tracked')
+        : fail('whatsapp-click-track', 'WhatsApp click tracked', "no uwc('click', { label: 'whatsapp-…' }) call")
+    },
+  },
+  {
+    group: 'Tracking', id: 'product-impression-track', name: 'Product impression tracked',
+    run: async (ctx) => {
+      const ok = await grepProject(ctx, /uwc\(['"]impression['"][^)]*product-/)
+      return ok
+        ? pass('product-impression-track', 'Product impression tracked')
+        : fail('product-impression-track', 'Product impression tracked', "no uwc('impression', { label: 'product-…' }) call")
+    },
+  },
+  {
+    group: 'Tracking', id: 'blog-click-track', name: 'Blog article click tracked',
+    run: async (ctx) => {
+      const ok = await grepProject(ctx, /uwc\(['"]click['"][^)]*blog-/)
+      return ok
+        ? pass('blog-click-track', 'Blog article click tracked')
+        : fail('blog-click-track', 'Blog article click tracked', "no uwc('click', { label: 'blog-…' }) call")
+    },
+  },
+]
+
+const DESIGN: Check[] = [
+  {
+    group: 'Design', id: 'font-house-style', name: 'Uses Inter or Plus Jakarta Sans',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'app/[locale]/layout.tsx')
+      if (!c) return fail('font-house-style', 'Uses Inter or Plus Jakarta Sans', 'layout.tsx missing')
+      const ok = /\bInter\b|\bPlus_Jakarta_Sans\b/.test(c)
+      return ok
+        ? pass('font-house-style', 'Uses Inter or Plus Jakarta Sans')
+        : fail('font-house-style', 'Uses Inter or Plus Jakarta Sans', 'no Inter / Plus_Jakarta_Sans import in layout')
+    },
+  },
+  {
+    group: 'Design', id: 'no-forbidden-serifs', name: 'No forbidden serif display fonts',
+    run: async (ctx) => {
+      const bad = await grepProject(ctx, /\b(Cormorant|Fraunces|Playfair|EB_Garamond|Garamond_EB)\b/)
+      return bad
+        ? fail('no-forbidden-serifs', 'No forbidden serif display fonts', 'found Cormorant/Fraunces/Playfair/EB Garamond — house style is sans only')
+        : pass('no-forbidden-serifs', 'No forbidden serif display fonts')
+    },
+  },
+  {
+    group: 'Design', id: 'favicon', name: 'Favicon (app/icon.svg)',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, 'app/icon.svg')
+      return ok
+        ? pass('favicon', 'Favicon (app/icon.svg)')
+        : fail('favicon', 'Favicon (app/icon.svg)', 'Missing app/icon.svg')
+    },
+  },
+]
+
+const DATABASE: Check[] = [
+  {
+    group: 'Database', id: 'db-company-website', name: 'company_websites row',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('db-company-website', 'company_websites row', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('db-company-website', 'company_websites row', 'unknown domain')
+      const c = await getDomainCounts(ctx.info.domainCandidates)
+      if (c.companyWebsites == null) return skip('db-company-website', 'company_websites row', 'query failed')
+      return c.companyWebsites > 0
+        ? pass('db-company-website', 'company_websites row', `${c.companyWebsites} row(s) matched`)
+        : fail('db-company-website', 'company_websites row', `no row for ${c.matchedAgainst.join(' | ')}`)
+    },
+  },
+  {
+    group: 'Database', id: 'db-phone-number', name: 'phone_numbers row (active)',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('db-phone-number', 'phone_numbers row (active)', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('db-phone-number', 'phone_numbers row (active)', 'unknown domain')
+      const c = await getDomainCounts(ctx.info.domainCandidates)
+      if (c.phoneNumbers == null) return skip('db-phone-number', 'phone_numbers row (active)', 'query failed')
+      return c.phoneNumbers > 0
+        ? pass('db-phone-number', 'phone_numbers row (active)', `${c.phoneNumbers} active number(s)`)
+        : fail('db-phone-number', 'phone_numbers row (active)', `no active rows for ${c.matchedAgainst.join(' | ')}`)
+    },
+  },
+  {
+    group: 'Database', id: 'db-products', name: 'Active products in Supabase',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('db-products', 'Active products in Supabase', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('db-products', 'Active products in Supabase', 'unknown domain')
+      const c = await getDomainCounts(ctx.info.domainCandidates)
+      if (c.activeProducts == null) return skip('db-products', 'Active products in Supabase', 'query failed')
+      return c.activeProducts > 0
+        ? pass('db-products', 'Active products in Supabase', `${c.activeProducts} active product(s)`)
+        : fail('db-products', 'Active products in Supabase', `0 active products for ${c.matchedAgainst.join(' | ')}`)
+    },
+  },
+  {
+    group: 'Database', id: 'db-blog-posts', name: '≥10 published blog posts',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('db-blog-posts', '≥10 published blog posts', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('db-blog-posts', '≥10 published blog posts', 'unknown domain')
+      const c = await getDomainCounts(ctx.info.domainCandidates)
+      if (c.publishedBlogPosts == null) return skip('db-blog-posts', '≥10 published blog posts', 'query failed')
+      return c.publishedBlogPosts >= 10
+        ? pass('db-blog-posts', '≥10 published blog posts', `${c.publishedBlogPosts} published post(s)`)
+        : fail('db-blog-posts', '≥10 published blog posts', `only ${c.publishedBlogPosts} published post(s)`)
+    },
+  },
+]
+
+const DEPLOYMENT: Check[] = [
+  {
+    group: 'Deployment', id: 'vercel-linked', name: 'Vercel project linked',
+    run: async (ctx) => {
+      const ok = await fileExists(ctx, '.vercel/project.json')
+      return ok
+        ? pass('vercel-linked', 'Vercel project linked')
+        : fail('vercel-linked', 'Vercel project linked', 'Missing .vercel/project.json — run `vercel link`')
+    },
+  },
+  {
+    group: 'Deployment', id: 'deploy-url-live', name: 'Deploy URL responds',
+    run: async (ctx) => {
+      const url = ctx.info.deployUrl
+      if (!url) return fail('deploy-url-live', 'Deploy URL responds', 'no deploy URL — not deployed yet')
+      try {
+        const res = await fetch(url, { method: 'HEAD', redirect: 'manual', signal: AbortSignal.timeout(4000) })
+        if (res.ok || res.status === 307 || res.status === 308 || res.status === 301 || res.status === 302) {
+          return pass('deploy-url-live', 'Deploy URL responds', url)
+        }
+        return fail('deploy-url-live', 'Deploy URL responds', `${url} returned ${res.status}`)
+      } catch {
+        return fail('deploy-url-live', 'Deploy URL responds', `${url} unreachable`)
+      }
+    },
+  },
+  {
+    group: 'Deployment', id: 'live-db-connected', name: 'Live site reads phone from Supabase',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('live-db-connected', 'Live site reads phone from Supabase', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('live-db-connected', 'Live site reads phone from Supabase', 'unknown domain')
+
+      const [phones, registered] = await Promise.all([
+        getPhoneRows(ctx.info.domainCandidates),
+        getRegisteredDomains(ctx.info.domainCandidates),
+      ])
+
+      const baseUrls: string[] = []
+      if (registered) for (const r of registered) baseUrls.push(`https://${r.domain}`)
+      if (ctx.info.deployUrl) baseUrls.push(ctx.info.deployUrl)
+      for (const d of ctx.info.domainCandidates) {
+        const u = `https://${d}`
+        if (!baseUrls.includes(u)) baseUrls.push(u)
+      }
+
+      const dbPhones = (phones ?? []).filter((p) => p.is_active).map((p) => p.phone_number)
+      const status = await checkLiveDbConnection({
+        baseUrls: Array.from(new Set(baseUrls)),
+        dbPhones,
+        fallbackPhone: ctx.info.fallbackPhone,
+      })
+
+      if (status.status === 'connected') return pass('live-db-connected', 'Live site reads phone from Supabase', `live=${status.livePhone}`)
+      if (status.status === 'no-target') return skip('live-db-connected', 'Live site reads phone from Supabase', 'no deploy URL')
+      if (status.status === 'no-response') return fail('live-db-connected', 'Live site reads phone from Supabase', 'no candidate URL returned a wa.me link')
+      if (status.status === 'fallback') return fail('live-db-connected', 'Live site reads phone from Supabase', `live=${status.livePhone} (fallback), DB=${dbPhones.join(', ') || '—'}`)
+      return fail('live-db-connected', 'Live site reads phone from Supabase', status.detail)
+    },
+  },
+]
+
+const QUALITY: Check[] = [
+  {
+    group: 'Quality', id: 'no-hardcoded-phones', name: 'No hardcoded phone numbers in app/ or components/',
+    run: async (ctx) => {
+      const hits = await findHardcodedPhones(ctx.info.projectDir)
+      if (hits.length === 0) return pass('no-hardcoded-phones', 'No hardcoded phone numbers in app/ or components/')
+      const first = hits[0]
+      return fail(
+        'no-hardcoded-phones',
+        'No hardcoded phone numbers in app/ or components/',
+        `${hits.length} hit(s) — e.g. ${first.file}:${first.line} → ${first.match}`,
+      )
+    },
+  },
+  {
+    group: 'Quality', id: 'no-hardcoded-phones-blog', name: 'No hardcoded phone numbers in blog content',
+    run: async (ctx) => {
+      if (!supabaseConfigured) return skip('no-hardcoded-phones-blog', 'No hardcoded phone numbers in blog content', 'Supabase not configured')
+      if (ctx.info.domainCandidates.length === 0) return skip('no-hardcoded-phones-blog', 'No hardcoded phone numbers in blog content', 'unknown domain')
+      const rows = await getBlogContentRows(ctx.info.domainCandidates)
+      if (rows == null) return skip('no-hardcoded-phones-blog', 'No hardcoded phone numbers in blog content', 'query failed')
+      const hits = findBlogHardcodedPhones(rows)
+      if (hits.length === 0) return pass('no-hardcoded-phones-blog', 'No hardcoded phone numbers in blog content')
+      const first = hits[0]
+      return fail(
+        'no-hardcoded-phones-blog',
+        'No hardcoded phone numbers in blog content',
+        `${hits.length} hit(s) — e.g. [${first.post_slug}/${first.language}/${first.field}] ${first.match}`,
+      )
+    },
+  },
+]
+
+const ALL_CHECKS: Check[] = [
+  ...STRUCTURE,
+  ...SEO,
+  ...I18N,
+  ...WEBCORE,
+  ...TRACKING,
+  ...DESIGN,
+  ...DATABASE,
+  ...DEPLOYMENT,
+  ...QUALITY,
+]
+
+export async function runChecksForProject(info: ProjectInfo): Promise<CheckGroup[]> {
+  const ctx: Ctx = { info, fileCache: new Map(), grepCache: new Map() }
+  const results = await Promise.all(ALL_CHECKS.map((c) => c.run(ctx)))
+
+  const byGroup = new Map<string, CheckResult[]>()
+  ALL_CHECKS.forEach((c, i) => {
+    if (!byGroup.has(c.group)) byGroup.set(c.group, [])
+    byGroup.get(c.group)!.push(results[i])
+  })
+
+  return Array.from(byGroup.entries()).map(([name, items]) => ({ name, items }))
+}
+
+export function totalCheckCount(): number {
+  return ALL_CHECKS.length
+}

--- a/utopia-fairy/lib/dataSource.ts
+++ b/utopia-fairy/lib/dataSource.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides whether the API serves live scans (filesystem available) or
+ * snapshots (deployed mode — projects/ doesn't exist).
+ *
+ *   UTOPIA_FAIRY_USE_SNAPSHOTS=1     → always snapshots, even if projects/ exists
+ *   UTOPIA_FAIRY_USE_LIVE=1          → always live (errors if projects/ missing)
+ *   default                          → live if projects/ exists, else snapshots
+ */
+
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+export function projectsDir(): string {
+  // utopia-fairy/ → ../projects
+  return path.resolve(process.cwd(), '..', 'projects')
+}
+
+export type DataMode = 'live' | 'snapshot'
+
+let cachedMode: DataMode | null = null
+
+export function dataMode(): DataMode {
+  if (cachedMode) return cachedMode
+  if (process.env.UTOPIA_FAIRY_USE_SNAPSHOTS === '1') {
+    cachedMode = 'snapshot'
+    return cachedMode
+  }
+  if (process.env.UTOPIA_FAIRY_USE_LIVE === '1') {
+    cachedMode = 'live'
+    return cachedMode
+  }
+  cachedMode = existsSync(projectsDir()) ? 'live' : 'snapshot'
+  return cachedMode
+}

--- a/utopia-fairy/lib/liveStatusCheck.ts
+++ b/utopia-fairy/lib/liveStatusCheck.ts
@@ -1,0 +1,112 @@
+export type LiveStatus = 'connected' | 'fallback' | 'unexpected' | 'no-target' | 'no-response'
+
+export interface LiveDbStatus {
+  status: LiveStatus
+  targetUrl: string | null
+  livePhone: string | null
+  dbPhones: string[]
+  fallbackPhone: string | null
+  detail: string
+}
+
+interface Args {
+  baseUrls: string[]      // URLs to try (e.g. https://example.com), in priority order
+  dbPhones: string[]      // phones the DB says we should be using
+  fallbackPhone: string | null
+}
+
+const cache = new Map<string, { ts: number; value: LiveDbStatus }>()
+const TTL = 60_000
+
+function cacheKey({ baseUrls, dbPhones, fallbackPhone }: Args): string {
+  return JSON.stringify({ baseUrls, dbPhones, fallbackPhone })
+}
+
+async function probe(baseUrl: string): Promise<string | null> {
+  const url = `${baseUrl.replace(/\/$/, '')}/en/redirect-whatsapp-1`
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(7000),
+      redirect: 'follow',
+      cache: 'no-store',
+    })
+    if (!res.ok) return null
+    const html = await res.text()
+    const m = html.match(/wa\.me\/(\d+)/)
+    return m ? m[1] : null
+  } catch {
+    return null
+  }
+}
+
+export async function checkLiveDbConnection(args: Args): Promise<LiveDbStatus> {
+  const key = cacheKey(args)
+  const cached = cache.get(key)
+  if (cached && Date.now() - cached.ts < TTL) return cached.value
+
+  const { baseUrls, dbPhones, fallbackPhone } = args
+  if (baseUrls.length === 0) {
+    const value: LiveDbStatus = {
+      status: 'no-target',
+      targetUrl: null,
+      livePhone: null,
+      dbPhones,
+      fallbackPhone,
+      detail: 'no deploy URL — site not deployed yet',
+    }
+    cache.set(key, { ts: Date.now(), value })
+    return value
+  }
+
+  for (const baseUrl of baseUrls) {
+    const live = await probe(baseUrl)
+    if (!live) continue
+
+    const target = `${baseUrl.replace(/\/$/, '')}/en/redirect-whatsapp-1`
+    let value: LiveDbStatus
+    if (dbPhones.includes(live)) {
+      value = {
+        status: 'connected',
+        targetUrl: target,
+        livePhone: live,
+        dbPhones,
+        fallbackPhone,
+        detail: `live site is serving the DB phone ${live}`,
+      }
+    } else if (fallbackPhone && live === fallbackPhone) {
+      value = {
+        status: 'fallback',
+        targetUrl: target,
+        livePhone: live,
+        dbPhones,
+        fallbackPhone,
+        detail: dbPhones.length === 0
+          ? `live site is using the config/site.ts fallback ${live} (no DB phone seeded)`
+          : `live site is using the config/site.ts fallback ${live} instead of DB phone ${dbPhones.join(', ')} — deployment cannot read from Supabase (env vars missing or cache stale)`,
+      }
+    } else {
+      value = {
+        status: 'unexpected',
+        targetUrl: target,
+        livePhone: live,
+        dbPhones,
+        fallbackPhone,
+        detail: `live site is serving ${live}, which matches neither the DB phones (${dbPhones.join(', ') || '—'}) nor the fallback (${fallbackPhone ?? '—'})`,
+      }
+    }
+    cache.set(key, { ts: Date.now(), value })
+    return value
+  }
+
+  const value: LiveDbStatus = {
+    status: 'no-response',
+    targetUrl: `${baseUrls[0].replace(/\/$/, '')}/en/redirect-whatsapp-1`,
+    livePhone: null,
+    dbPhones,
+    fallbackPhone,
+    detail: `no candidate URL returned a parseable wa.me link (tried ${baseUrls.length})`,
+  }
+  cache.set(key, { ts: Date.now(), value })
+  return value
+}

--- a/utopia-fairy/lib/projectInfo.ts
+++ b/utopia-fairy/lib/projectInfo.ts
@@ -1,0 +1,83 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
+export interface ProjectInfo {
+  slug: string
+  projectDir: string
+  domain: string | null
+  productSlug: string | null
+  fallbackPhone: string | null
+  deployUrl: string | null
+  domainCandidates: string[]
+}
+
+function extractStringField(content: string, field: string): string | null {
+  const re = new RegExp(`\\b${field}\\b[^'"\\n]*['"]([A-Za-z0-9.\\-_/]+)['"]`)
+  const m = content.match(re)
+  return m ? m[1] : null
+}
+
+function extractDataWebsite(content: string): string | null {
+  const m = content.match(/data-website=["']([^"']+)["']/)
+  return m ? m[1] : null
+}
+
+function hostOf(url: string | null): string | null {
+  if (!url) return null
+  try { return new URL(url).host } catch { return null }
+}
+
+export async function getProjectInfo(slug: string, projectsDir: string): Promise<ProjectInfo> {
+  const projectDir = path.join(projectsDir, slug)
+  let domain: string | null = null
+  let productSlug: string | null = null
+  let dataWebsite: string | null = null
+  let fallbackPhone: string | null = null
+
+  try {
+    const site = await readFile(path.join(projectDir, 'config', 'site.ts'), 'utf-8')
+    domain = extractStringField(site, 'domain')
+    productSlug = extractStringField(site, 'productSlug')
+    fallbackPhone = extractStringField(site, 'fallbackPhone')
+  } catch { /* no site.ts yet */ }
+
+  try {
+    const layout = await readFile(path.join(projectDir, 'app', '[locale]', 'layout.tsx'), 'utf-8')
+    dataWebsite = extractDataWebsite(layout)
+  } catch { /* no layout */ }
+
+  let deployUrl: string | null = null
+  try {
+    deployUrl = (await readFile(path.join(projectDir, 'deploy-url.txt'), 'utf-8')).trim()
+  } catch {
+    try {
+      const vp = JSON.parse(
+        await readFile(path.join(projectDir, '.vercel', 'project.json'), 'utf-8'),
+      )
+      if (vp.projectName) deployUrl = `https://${vp.projectName}.vercel.app`
+    } catch { /* no vercel config */ }
+  }
+
+  // Collect every plausible domain alias so DB checks can match registrations
+  // under custom domains (.com.my) or `.utopiaai.my` aliases.
+  const candidates = new Set<string>()
+  if (domain) {
+    candidates.add(domain)
+    candidates.add(domain.replace(/\.vercel\.app$/, '.utopiaai.my'))
+  }
+  if (dataWebsite) candidates.add(dataWebsite)
+  const deployHost = hostOf(deployUrl)
+  if (deployHost) candidates.add(deployHost)
+  // Common fallback: <slug>.vercel.app
+  candidates.add(`${slug}.vercel.app`)
+
+  return {
+    slug,
+    projectDir,
+    domain,
+    productSlug,
+    fallbackPhone,
+    deployUrl,
+    domainCandidates: Array.from(candidates).filter(Boolean),
+  }
+}

--- a/utopia-fairy/lib/runChecklist.ts
+++ b/utopia-fairy/lib/runChecklist.ts
@@ -1,0 +1,128 @@
+import { getProjectInfo, ProjectInfo } from './projectInfo'
+import { runChecksForProject, CheckGroup, totalCheckCount } from './checklist'
+import { findRegisteredDomainsByPhone, findRegisteredDomainsByKeyword } from './supabaseChecks'
+
+export interface ChecklistRun {
+  slug: string
+  domain: string | null
+  productSlug: string | null
+  fallbackPhone: string | null
+  deployUrl: string | null
+  domainCandidates: string[]
+  passed: number
+  total: number
+  failedCount: number
+  groups: CheckGroup[]
+  ranAt: string
+}
+
+interface Cached { value: ChecklistRun; ts: number }
+const cache = new Map<string, Cached>()
+const TTL = 60_000
+
+const STOP_TOKENS = new Set(['malaysia', 'my', 'sdn', 'bhd'])
+const TIME_TOKEN = /^(jam|hour|hours|minute|min|day|days)$/i
+
+function slugKeywords(slug: string): string[] {
+  // Strip generic tokens (country, units, pure numbers) and try two variants:
+  //   1. joined  → 'electricwheelchair' (more specific, try first)
+  //   2. first   → 'electrician'        (fallback when joined misses)
+  // We always try the more specific first so 'electric' (too generic) only
+  // gets used when 'electricwheelchair' returns no rows.
+  const tokens = slug.split('-').filter((t) => {
+    if (!t || STOP_TOKENS.has(t.toLowerCase())) return false
+    if (/^\d+$/.test(t)) return false
+    if (TIME_TOKEN.test(t)) return false
+    return true
+  })
+  if (tokens.length === 0) return []
+
+  const out: string[] = []
+  const joined = tokens.join('').toLowerCase()
+  if (joined.length >= 4) out.push(joined)
+
+  const first = tokens[0].toLowerCase()
+  if (first.length >= 6 && first !== joined) out.push(first)
+
+  return out
+}
+
+async function expandCandidates(info: ProjectInfo): Promise<ProjectInfo> {
+  const extras = new Set<string>()
+
+  // (a) Slug keyword → company_websites ilike match. Reliably finds custom
+  // domains like `electricwheelchairmalaysia.com.my` for slug
+  // `electric-wheelchair-malaysia` without pulling in unrelated sites.
+  // Try the specific keyword first, fall back to the first token only if
+  // the specific one returned nothing.
+  for (const kw of slugKeywords(info.slug)) {
+    const matches = await findRegisteredDomainsByKeyword(kw)
+    if (matches.length > 0) {
+      for (const d of matches) extras.add(d)
+      break
+    }
+  }
+
+  // (b) Fallback phone → phone_numbers lookup, but only when the phone is
+  // unique to ONE website. Shared/template phones (e.g. the same number
+  // across 6 sister sites) would otherwise pollute the candidate list.
+  if (info.fallbackPhone) {
+    const byPhone = await findRegisteredDomainsByPhone(info.fallbackPhone)
+    if (byPhone.length === 1) extras.add(byPhone[0])
+  }
+
+  if (extras.size === 0) return info
+  const merged = Array.from(new Set([...info.domainCandidates, ...extras]))
+  return { ...info, domainCandidates: merged }
+}
+
+export async function runChecklist(
+  slug: string,
+  projectsDir: string,
+  useCache = true,
+): Promise<ChecklistRun> {
+  const cached = cache.get(slug)
+  if (useCache && cached && Date.now() - cached.ts < TTL) return cached.value
+
+  const base = await getProjectInfo(slug, projectsDir)
+  const info = await expandCandidates(base)
+  const groups = await runChecksForProject(info)
+
+  // Every check counts toward the denominator so totals are consistent
+  // across projects. Skipped items (missing prerequisites) read as "not yet
+  // passing" rather than disappearing from the score.
+  const total = totalCheckCount()
+  let passed = 0
+  let failedCount = 0
+  for (const g of groups) {
+    for (const item of g.items) {
+      if (item.status === 'pass') passed++
+      else if (item.status === 'fail') failedCount++
+    }
+  }
+
+  const value: ChecklistRun = {
+    slug,
+    domain: info.domain,
+    productSlug: info.productSlug,
+    fallbackPhone: info.fallbackPhone,
+    deployUrl: info.deployUrl,
+    domainCandidates: info.domainCandidates,
+    passed,
+    total,
+    failedCount,
+    groups,
+    ranAt: new Date().toISOString(),
+  }
+  cache.set(slug, { value, ts: Date.now() })
+  return value
+}
+
+/**
+ * Return the full ProjectInfo (including DB-expanded candidates) for a slug.
+ * Used by the data-view endpoint so it sees the same expanded alias list.
+ */
+export async function getExpandedProjectInfo(slug: string, projectsDir: string): Promise<ProjectInfo> {
+  const base = await getProjectInfo(slug, projectsDir)
+  return expandCandidates(base)
+}

--- a/utopia-fairy/lib/snapshotStore.ts
+++ b/utopia-fairy/lib/snapshotStore.ts
@@ -1,0 +1,107 @@
+/**
+ * Storage adapter for monitor_snapshots. Reads use the anon key (so the
+ * deployed monitor only needs NEXT_PUBLIC_SUPABASE_*). Writes use the service
+ * role key and are intended to run only from the CLI scanner.
+ */
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? ''
+const ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY ?? ''
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ''
+
+export interface SnapshotRow {
+  slug: string
+  ran_at: string
+  total: number
+  passed: number
+  failed_count: number
+  domain: string | null
+  product_slug: string | null
+  fallback_phone: string | null
+  deploy_url: string | null
+  domain_candidates: string[]
+  groups: unknown
+  registered: unknown
+  phones: unknown
+  products: unknown
+  blogs: unknown
+  hardcoded: unknown
+  blog_hardcoded: unknown
+  live_status: unknown
+}
+
+function ensureRead() {
+  if (!SUPABASE_URL || !ANON_KEY) {
+    throw new Error('snapshotStore: NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY not set')
+  }
+}
+
+function ensureWrite() {
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    throw new Error('snapshotStore: SUPABASE_SERVICE_ROLE_KEY not set — required for writing snapshots')
+  }
+}
+
+export async function readAllSnapshots(): Promise<SnapshotRow[]> {
+  ensureRead()
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/monitor_snapshots?select=*&order=ran_at.desc`, {
+    headers: { apikey: ANON_KEY, Authorization: `Bearer ${ANON_KEY}` },
+    cache: 'no-store',
+  })
+  if (!res.ok) throw new Error(`readAllSnapshots: HTTP ${res.status}`)
+  return res.json()
+}
+
+export async function readSnapshot(slug: string): Promise<SnapshotRow | null> {
+  ensureRead()
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/monitor_snapshots?slug=eq.${encodeURIComponent(slug)}&select=*&limit=1`,
+    {
+      headers: { apikey: ANON_KEY, Authorization: `Bearer ${ANON_KEY}` },
+      cache: 'no-store',
+    },
+  )
+  if (!res.ok) throw new Error(`readSnapshot: HTTP ${res.status}`)
+  const rows = (await res.json()) as SnapshotRow[]
+  return rows[0] ?? null
+}
+
+export async function upsertSnapshot(row: Omit<SnapshotRow, 'ran_at'> & { ran_at?: string }): Promise<void> {
+  ensureWrite()
+  const body = { ...row, ran_at: row.ran_at ?? new Date().toISOString() }
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/monitor_snapshots?on_conflict=slug`, {
+    method: 'POST',
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'resolution=merge-duplicates,return=minimal',
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`upsertSnapshot ${row.slug}: HTTP ${res.status} ${text.slice(0, 200)}`)
+  }
+}
+
+export async function deleteSnapshotsExcept(keepSlugs: string[]): Promise<number> {
+  ensureWrite()
+  // Build a NOT-IN filter so we prune rows for projects that no longer exist.
+  const list = keepSlugs.map((s) => `"${s.replace(/"/g, '\\"')}"`).join(',')
+  const url = keepSlugs.length === 0
+    ? `${SUPABASE_URL}/rest/v1/monitor_snapshots`
+    : `${SUPABASE_URL}/rest/v1/monitor_snapshots?slug=not.in.(${list})`
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      Prefer: 'return=representation',
+    },
+  })
+  if (!res.ok) throw new Error(`deleteSnapshotsExcept: HTTP ${res.status}`)
+  const removed = (await res.json()) as unknown[]
+  return removed.length
+}

--- a/utopia-fairy/lib/sourceScan.ts
+++ b/utopia-fairy/lib/sourceScan.ts
@@ -1,0 +1,141 @@
+import { readFile, readdir } from 'fs/promises'
+import path from 'path'
+
+export interface HardcodedPhone {
+  file: string
+  line: number
+  match: string
+  excerpt: string
+}
+
+const SKIP_DIRS = new Set(['node_modules', '.next', '.vercel', '.git', 'temporary screenshots', 'brand_assets', 'dist', 'build'])
+const SCAN_EXTS = ['.tsx', '.ts', '.jsx', '.js']
+
+// Match Malaysian phone numbers in raw or formatted forms.
+export const PHONE_PATTERNS = [
+  /\+60\d{8,11}/g,                        // +60123456789
+  /\b60[1-9]\d{7,10}\b/g,                 // 60123456789
+  /\b01[0-9]\s?-?\s?\d{3,4}\s?-?\s?\d{4}\b/g, // 0123 456 7890, 012-345-6789, etc.
+]
+
+/**
+ * Scan an arbitrary text blob for phone numbers. Returns one hit per unique
+ * starting offset (so `+60174287801` doesn't show up twice from the `+60`
+ * and `60…` patterns both matching the same span).
+ */
+export function scanTextForPhones(text: string): { match: string; index: number; excerpt: string }[] {
+  const byOffset = new Map<number, { match: string; index: number; excerpt: string }>()
+  for (const re of PHONE_PATTERNS) {
+    re.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      const start = Math.max(0, m.index - 50)
+      const end = Math.min(text.length, m.index + m[0].length + 50)
+      const excerpt = text.slice(start, end).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim().slice(0, 160)
+      const prev = byOffset.get(m.index)
+      if (!prev || m[0].length > prev.match.length) {
+        byOffset.set(m.index, { match: m[0], index: m.index, excerpt })
+      }
+    }
+  }
+  return Array.from(byOffset.values()).sort((a, b) => a.index - b.index)
+}
+
+async function walk(dir: string, repoRoot: string, hits: HardcodedPhone[]): Promise<void> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue
+    const p = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      await walk(p, repoRoot, hits)
+    } else if (SCAN_EXTS.some((x) => e.name.endsWith(x))) {
+      try {
+        const content = await readFile(p, 'utf-8')
+        const lines = content.split('\n')
+        for (let i = 0; i < lines.length; i++) {
+          for (const h of scanTextForPhones(lines[i])) {
+            hits.push({
+              file: path.relative(repoRoot, p),
+              line: i + 1,
+              match: h.match,
+              excerpt: lines[i].trim().slice(0, 160),
+            })
+          }
+        }
+      } catch { /* skip unreadable */ }
+    }
+  }
+}
+
+/**
+ * Scan a project for hardcoded phone numbers in user-facing source code.
+ * Only inspects app/ and components/ — config/site.ts (fallbackPhone) and
+ * lib/webcore.ts (FALLBACK_PHONE constant) are the legitimate places for
+ * the literal number, so we skip them.
+ */
+export interface BlogHardcodedPhone {
+  post_slug: string
+  language: string
+  field: 'title' | 'content' | 'excerpt' | 'meta_title' | 'meta_description'
+  match: string
+  excerpt: string
+}
+
+interface BlogContentInput {
+  slug: string
+  blog_translations: {
+    language: string
+    title: string | null
+    content: string | null
+    excerpt: string | null
+    meta_title: string | null
+    meta_description: string | null
+  }[]
+}
+
+const BLOG_FIELDS: BlogHardcodedPhone['field'][] = ['title', 'content', 'excerpt', 'meta_title', 'meta_description']
+
+export function findBlogHardcodedPhones(rows: BlogContentInput[] | null): BlogHardcodedPhone[] {
+  if (!rows) return []
+  const hits: BlogHardcodedPhone[] = []
+  for (const post of rows) {
+    for (const t of post.blog_translations ?? []) {
+      for (const field of BLOG_FIELDS) {
+        const text = t[field]
+        if (!text) continue
+        for (const h of scanTextForPhones(text)) {
+          hits.push({
+            post_slug: post.slug,
+            language: t.language,
+            field,
+            match: h.match,
+            excerpt: h.excerpt,
+          })
+        }
+      }
+    }
+  }
+  return hits
+}
+
+export async function findHardcodedPhones(projectDir: string): Promise<HardcodedPhone[]> {
+  const raw: HardcodedPhone[] = []
+  await walk(path.join(projectDir, 'app'), projectDir, raw)
+  await walk(path.join(projectDir, 'components'), projectDir, raw)
+
+  // Multiple patterns can match the same number on the same line (e.g.
+  // `+60174287801` matches both the `+60…` and `60…` patterns). Keep only
+  // the longest match per file:line so each occurrence shows once.
+  const byKey = new Map<string, HardcodedPhone>()
+  for (const h of raw) {
+    const key = `${h.file}:${h.line}`
+    const prev = byKey.get(key)
+    if (!prev || h.match.length > prev.match.length) byKey.set(key, h)
+  }
+  return Array.from(byKey.values())
+}

--- a/utopia-fairy/lib/supabaseChecks.ts
+++ b/utopia-fairy/lib/supabaseChecks.ts
@@ -1,0 +1,244 @@
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? ''
+const SUPABASE_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY ?? ''
+
+export const supabaseConfigured = !!(SUPABASE_URL && SUPABASE_KEY)
+
+interface CountOpts {
+  table: string
+  filter: string
+}
+
+export async function countRows({ table, filter }: CountOpts): Promise<number | null> {
+  if (!supabaseConfigured) return null
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${filter}&select=id`, {
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+        Prefer: 'count=exact',
+        Range: '0-0',
+      },
+      signal: AbortSignal.timeout(5000),
+      cache: 'no-store',
+    })
+    if (!res.ok) return null
+    const range = res.headers.get('content-range') || ''
+    const m = range.match(/\/(\d+|\*)$/)
+    if (!m || m[1] === '*') return null
+    return parseInt(m[1], 10)
+  } catch {
+    return null
+  }
+}
+
+interface DomainCounts {
+  companyWebsites: number | null
+  phoneNumbers: number | null
+  activeProducts: number | null
+  publishedBlogPosts: number | null
+  matchedAgainst: string[]
+}
+
+const cache = new Map<string, { ts: number; counts: DomainCounts }>()
+const TTL = 60_000
+
+function inFilter(field: string, candidates: string[]): string {
+  // PostgREST `in.(a,b,c)` — values must be comma-separated, URL-encoded
+  const list = candidates.map((c) => encodeURIComponent(c)).join(',')
+  return `${field}=in.(${list})`
+}
+
+interface RestOpts {
+  table: string
+  filter: string
+  select: string
+}
+
+async function selectRows<T = unknown>({ table, filter, select }: RestOpts): Promise<T[] | null> {
+  if (!supabaseConfigured) return null
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}?${filter}&select=${encodeURIComponent(select)}`, {
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+      },
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    })
+    if (!res.ok) return null
+    return (await res.json()) as T[]
+  } catch {
+    return null
+  }
+}
+
+export interface PhoneRow {
+  phone_number: string
+  label: string | null
+  location_slug: string | null
+  whatsapp_text: string | null
+  percentage: number | null
+  type: string | null
+  is_active: boolean
+}
+
+export interface ProductRow {
+  name: string
+  slug: string
+  description: string | null
+  sale_price: number | null
+  rental_price: number | null
+  sort_order: number | null
+  is_active: boolean
+  product_photos: { url: string }[]
+}
+
+export interface BlogRow {
+  slug: string
+  status: string
+  cover_image_url: string | null
+  blog_translations: { language: string; title: string | null }[]
+}
+
+export interface RegisteredDomain {
+  domain: string
+  leads_mode: string | null
+  company_id: string | null
+}
+
+export async function findRegisteredDomainsByPhone(phone: string): Promise<string[]> {
+  if (!supabaseConfigured) return []
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/phone_numbers?phone_number=eq.${encodeURIComponent(phone)}&select=website`, {
+      headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+      signal: AbortSignal.timeout(5000),
+      cache: 'no-store',
+    })
+    if (!res.ok) return []
+    const rows = (await res.json()) as { website: string }[]
+    return Array.from(new Set(rows.map((r) => r.website).filter(Boolean)))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Search `company_websites` for any domain matching a keyword substring.
+ * Used to discover that e.g. `electric-wheelchair-malaysia` (folder slug)
+ * is registered as `electricwheelchairmalaysia.com.my` (custom domain).
+ */
+export async function findRegisteredDomainsByKeyword(keyword: string): Promise<string[]> {
+  if (!supabaseConfigured || keyword.length < 4) return []
+  try {
+    const enc = encodeURIComponent(`*${keyword}*`)
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/company_websites?domain=ilike.${enc}&select=domain`, {
+      headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+      signal: AbortSignal.timeout(5000),
+      cache: 'no-store',
+    })
+    if (!res.ok) return []
+    const rows = (await res.json()) as { domain: string }[]
+    return Array.from(new Set(rows.map((r) => r.domain).filter(Boolean)))
+  } catch {
+    return []
+  }
+}
+
+export async function getRegisteredDomains(candidates: string[]): Promise<RegisteredDomain[] | null> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) return []
+  return selectRows<RegisteredDomain>({
+    table: 'company_websites',
+    filter: inFilter('domain', dedup),
+    select: 'domain,leads_mode,company_id',
+  })
+}
+
+export async function getPhoneRows(candidates: string[]): Promise<PhoneRow[] | null> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) return []
+  return selectRows<PhoneRow>({
+    table: 'phone_numbers',
+    filter: inFilter('website', dedup),
+    select: 'phone_number,label,location_slug,whatsapp_text,percentage,type,is_active',
+  })
+}
+
+export async function getProductRows(candidates: string[]): Promise<ProductRow[] | null> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) return []
+  return selectRows<ProductRow>({
+    table: 'products',
+    filter: `${inFilter('website', dedup)}&order=sort_order.asc`,
+    select: 'name,slug,description,sale_price,rental_price,sort_order,is_active,product_photos(url)',
+  })
+}
+
+export interface BlogContentRow {
+  slug: string
+  blog_translations: {
+    language: string
+    title: string | null
+    content: string | null
+    excerpt: string | null
+    meta_title: string | null
+    meta_description: string | null
+  }[]
+}
+
+const blogContentCache = new Map<string, { ts: number; rows: BlogContentRow[] | null }>()
+
+export async function getBlogContentRows(candidates: string[]): Promise<BlogContentRow[] | null> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) return []
+  const key = dedup.slice().sort().join('|')
+  const cached = blogContentCache.get(key)
+  if (cached && Date.now() - cached.ts < TTL) return cached.rows
+  const rows = await selectRows<BlogContentRow>({
+    table: 'blog_posts',
+    filter: inFilter('website', dedup),
+    select: 'slug,blog_translations(language,title,content,excerpt,meta_title,meta_description)',
+  })
+  blogContentCache.set(key, { ts: Date.now(), rows })
+  return rows
+}
+
+export async function getBlogRows(candidates: string[]): Promise<BlogRow[] | null> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) return []
+  return selectRows<BlogRow>({
+    table: 'blog_posts',
+    filter: inFilter('website', dedup),
+    select: 'slug,status,cover_image_url,blog_translations(language,title)',
+  })
+}
+
+export async function getDomainCounts(candidates: string[]): Promise<DomainCounts> {
+  const dedup = Array.from(new Set(candidates)).filter(Boolean)
+  if (dedup.length === 0) {
+    return { companyWebsites: null, phoneNumbers: null, activeProducts: null, publishedBlogPosts: null, matchedAgainst: [] }
+  }
+
+  const key = dedup.slice().sort().join('|')
+  const cached = cache.get(key)
+  if (cached && Date.now() - cached.ts < TTL) return cached.counts
+
+  const [cw, ph, pr, bl] = await Promise.all([
+    countRows({ table: 'company_websites', filter: inFilter('domain', dedup) }),
+    countRows({ table: 'phone_numbers', filter: `${inFilter('website', dedup)}&is_active=eq.true` }),
+    countRows({ table: 'products', filter: `${inFilter('website', dedup)}&is_active=eq.true` }),
+    countRows({ table: 'blog_posts', filter: `${inFilter('website', dedup)}&status=eq.published` }),
+  ])
+
+  const counts: DomainCounts = {
+    companyWebsites: cw,
+    phoneNumbers: ph,
+    activeProducts: pr,
+    publishedBlogPosts: bl,
+    matchedAgainst: dedup,
+  }
+  cache.set(key, { ts: Date.now(), counts })
+  return counts
+}

--- a/utopia-fairy/lib/useMediaQuery.ts
+++ b/utopia-fairy/lib/useMediaQuery.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia(query)
+    const update = () => setMatches(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [query])
+  return matches
+}
+
+export function useIsMobile(): boolean {
+  return useMediaQuery('(max-width: 768px)')
+}

--- a/utopia-fairy/package-lock.json
+++ b/utopia-fairy/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "tailwindcss": "^4",
+        "tsx": "^4.22.3",
         "typescript": "^5"
       }
     },
@@ -42,6 +43,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -1073,6 +1516,63 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1638,6 +2138,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/utopia-fairy/package.json
+++ b/utopia-fairy/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev --port 3001",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "scan": "tsx scripts/scan.ts"
   },
   "dependencies": {
     "next": "16.2.1",
@@ -18,6 +19,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
+    "tsx": "^4.22.3",
     "typescript": "^5"
   }
 }

--- a/utopia-fairy/scripts/scan.ts
+++ b/utopia-fairy/scripts/scan.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env tsx
+/**
+ * Utopia Fairy snapshot scanner.
+ *
+ * Walks projects/*, runs every check + DB lookup, and upserts the result into
+ * monitor_snapshots. The deployed monitor reads from that table; this script
+ * is the only path that writes to it.
+ *
+ * Usage:
+ *   npm run scan            # from utopia-fairy/
+ *   npm run scan -- --dry   # don't write to Supabase, print payload
+ *
+ * Env required (load from repo-root .env.local; CI provides via secrets):
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   NEXT_PUBLIC_SUPABASE_ANON_KEY
+ *   SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import { readdir, stat, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+// Load .env.local from the repo root before importing anything that reads env.
+async function loadEnv(): Promise<void> {
+  const candidates = [
+    path.resolve(process.cwd(), '.env.local'),
+    path.resolve(process.cwd(), '..', '.env.local'),
+  ]
+  for (const file of candidates) {
+    if (!existsSync(file)) continue
+    const text = await readFile(file, 'utf-8')
+    for (const raw of text.split('\n')) {
+      const line = raw.trim()
+      if (!line || line.startsWith('#')) continue
+      const eq = line.indexOf('=')
+      if (eq === -1) continue
+      const key = line.slice(0, eq).trim()
+      let val = line.slice(eq + 1).trim()
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1)
+      }
+      if (!process.env[key]) process.env[key] = val
+    }
+    return
+  }
+}
+
+const DRY = process.argv.includes('--dry')
+const ONLY = process.argv.find((a) => a.startsWith('--only='))?.split('=')[1]
+
+// Imports must happen after env load — modules read env at module-load time.
+// We resolve them lazily inside main() so loadEnv() runs first.
+let runChecklist!: typeof import('../lib/runChecklist').runChecklist
+let getExpandedProjectInfo!: typeof import('../lib/runChecklist').getExpandedProjectInfo
+let getPhoneRows!: typeof import('../lib/supabaseChecks').getPhoneRows
+let getProductRows!: typeof import('../lib/supabaseChecks').getProductRows
+let getBlogRows!: typeof import('../lib/supabaseChecks').getBlogRows
+let getBlogContentRows!: typeof import('../lib/supabaseChecks').getBlogContentRows
+let getRegisteredDomains!: typeof import('../lib/supabaseChecks').getRegisteredDomains
+let findHardcodedPhones!: typeof import('../lib/sourceScan').findHardcodedPhones
+let findBlogHardcodedPhones!: typeof import('../lib/sourceScan').findBlogHardcodedPhones
+let checkLiveDbConnection!: typeof import('../lib/liveStatusCheck').checkLiveDbConnection
+let upsertSnapshot!: typeof import('../lib/snapshotStore').upsertSnapshot
+let deleteSnapshotsExcept!: typeof import('../lib/snapshotStore').deleteSnapshotsExcept
+
+async function loadModules(): Promise<void> {
+  const rc = await import('../lib/runChecklist')
+  runChecklist = rc.runChecklist
+  getExpandedProjectInfo = rc.getExpandedProjectInfo
+  const sc = await import('../lib/supabaseChecks')
+  getPhoneRows = sc.getPhoneRows
+  getProductRows = sc.getProductRows
+  getBlogRows = sc.getBlogRows
+  getBlogContentRows = sc.getBlogContentRows
+  getRegisteredDomains = sc.getRegisteredDomains
+  const ss = await import('../lib/sourceScan')
+  findHardcodedPhones = ss.findHardcodedPhones
+  findBlogHardcodedPhones = ss.findBlogHardcodedPhones
+  const ls = await import('../lib/liveStatusCheck')
+  checkLiveDbConnection = ls.checkLiveDbConnection
+  const st = await import('../lib/snapshotStore')
+  upsertSnapshot = st.upsertSnapshot
+  deleteSnapshotsExcept = st.deleteSnapshotsExcept
+}
+
+async function listProjectSlugs(projectsDir: string): Promise<string[]> {
+  const entries = await readdir(projectsDir)
+  const slugs: string[] = []
+  for (const slug of entries) {
+    try {
+      await stat(path.join(projectsDir, slug, 'inputs.md'))
+      slugs.push(slug)
+    } catch { /* not a project folder */ }
+  }
+  return slugs
+}
+
+async function buildPayloadForSlug(slug: string, projectsDir: string) {
+  // 1. Run the full checklist (uses cache internally — fine for one-shot run)
+  const checklist = await runChecklist(slug, projectsDir, /* useCache */ false)
+
+  // 2. Gather wish-data (same shape the /api/wish-data endpoint produces)
+  const info = await getExpandedProjectInfo(slug, projectsDir)
+  const [registered, phones, products, blogs, blogContent, hardcoded] = await Promise.all([
+    getRegisteredDomains(info.domainCandidates),
+    getPhoneRows(info.domainCandidates),
+    getProductRows(info.domainCandidates),
+    getBlogRows(info.domainCandidates),
+    getBlogContentRows(info.domainCandidates),
+    findHardcodedPhones(info.projectDir),
+  ])
+  const blogHardcoded = findBlogHardcodedPhones(blogContent)
+
+  const candidateBaseUrls: string[] = []
+  if (registered) for (const r of registered) candidateBaseUrls.push(`https://${r.domain}`)
+  if (info.deployUrl) candidateBaseUrls.push(info.deployUrl)
+  for (const d of info.domainCandidates) {
+    const u = `https://${d}`
+    if (!candidateBaseUrls.includes(u)) candidateBaseUrls.push(u)
+  }
+  const dbPhones = Array.from(new Set((phones ?? []).filter((p) => p.is_active).map((p) => p.phone_number)))
+  const liveStatus = await checkLiveDbConnection({
+    baseUrls: Array.from(new Set(candidateBaseUrls)),
+    dbPhones,
+    fallbackPhone: info.fallbackPhone,
+  })
+
+  return {
+    slug,
+    total: checklist.total,
+    passed: checklist.passed,
+    failed_count: checklist.failedCount,
+    domain: info.domain,
+    product_slug: info.productSlug,
+    fallback_phone: info.fallbackPhone,
+    deploy_url: info.deployUrl,
+    domain_candidates: info.domainCandidates,
+    groups: checklist.groups,
+    registered: registered ?? null,
+    phones: phones ?? null,
+    products: products ?? null,
+    blogs: blogs ?? null,
+    hardcoded,
+    blog_hardcoded: blogHardcoded,
+    live_status: liveStatus,
+  }
+}
+
+async function main(): Promise<void> {
+  await loadEnv()
+  await loadModules()
+
+  // Resolve projects/ relative to wherever the script runs from.
+  // Local: utopia-fairy/ → ../projects.   CI: repo root → ./projects.
+  const candidates = [
+    path.resolve(process.cwd(), '..', 'projects'),
+    path.resolve(process.cwd(), 'projects'),
+  ]
+  const projectsDir = candidates.find((p) => existsSync(p))
+  if (!projectsDir) {
+    console.error('scan: could not locate projects/ — tried', candidates)
+    process.exit(2)
+  }
+
+  const allSlugs = await listProjectSlugs(projectsDir)
+  const slugs = ONLY ? allSlugs.filter((s) => s === ONLY) : allSlugs
+  if (slugs.length === 0) {
+    console.error('scan: no projects matched', ONLY ? `(filter: ${ONLY})` : '')
+    process.exit(2)
+  }
+
+  console.log(`scan: ${slugs.length} project(s) under ${projectsDir}${DRY ? '  (dry run)' : ''}`)
+
+  let okCount = 0
+  let failCount = 0
+  const written: string[] = []
+
+  for (const slug of slugs) {
+    const t0 = Date.now()
+    try {
+      const payload = await buildPayloadForSlug(slug, projectsDir)
+      const elapsed = Date.now() - t0
+      console.log(
+        `  ✓ ${slug.padEnd(36)} ${String(payload.passed).padStart(2)}/${payload.total}` +
+        ` · live=${(payload.live_status as { status?: string }).status ?? '?'}` +
+        ` · ${elapsed}ms`,
+      )
+      if (!DRY) {
+        await upsertSnapshot(payload)
+        written.push(slug)
+      }
+      okCount++
+    } catch (err) {
+      failCount++
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`  ✗ ${slug}  — ${msg}`)
+    }
+  }
+
+  if (!DRY && !ONLY && written.length > 0) {
+    try {
+      const pruned = await deleteSnapshotsExcept(written)
+      if (pruned > 0) console.log(`scan: pruned ${pruned} snapshot(s) for removed projects`)
+    } catch (err) {
+      console.warn('scan: prune failed —', err instanceof Error ? err.message : err)
+    }
+  }
+
+  console.log(`scan: done · ${okCount} ok · ${failCount} failed${DRY ? ' (dry run, nothing written)' : ''}`)
+  if (failCount > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error('scan: crashed —', e instanceof Error ? e.stack ?? e.message : e)
+  process.exit(2)
+})

--- a/utopia-fairy/supabase/migrations/20260520_monitor_snapshots.sql
+++ b/utopia-fairy/supabase/migrations/20260520_monitor_snapshots.sql
@@ -1,0 +1,51 @@
+-- Utopia Fairy — monitor snapshots
+-- ----------------------------------------------------------------------------
+-- One row per project. The scanner (utopia-fairy/scripts/scan.ts, run from
+-- GitHub Actions) upserts the row each hour. The deployed monitor reads from
+-- this table via the anon key.
+--
+-- Run this once in the Supabase SQL Editor before deploying the monitor.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists monitor_snapshots (
+  slug            text primary key,
+  ran_at          timestamptz not null default now(),
+
+  -- Top-line scoring
+  total           int  not null,
+  passed          int  not null,
+  failed_count    int  not null,
+
+  -- Project metadata (parsed from config/site.ts)
+  domain          text,
+  product_slug    text,
+  fallback_phone  text,
+  deploy_url      text,
+  domain_candidates text[] not null default '{}',
+
+  -- Full payloads (kept as jsonb so the schema doesn't change every time we
+  -- add a check item). The deployed monitor reads these directly.
+  groups          jsonb not null,  -- ChecklistRun.groups
+  registered      jsonb,           -- company_websites rows
+  phones          jsonb,           -- phone_numbers rows
+  products        jsonb,           -- products + product_photos rows
+  blogs           jsonb,           -- blog_posts + blog_translations summary
+  hardcoded       jsonb,           -- source-file phone hits
+  blog_hardcoded  jsonb,           -- blog-content phone hits
+  live_status     jsonb            -- live DB connectivity probe result
+);
+
+create index if not exists monitor_snapshots_ran_at_idx
+  on monitor_snapshots (ran_at desc);
+
+-- Row Level Security: anon can read (deployed viewer), only service_role can
+-- write (CI scanner). Service role bypasses RLS by default.
+alter table monitor_snapshots enable row level security;
+
+drop policy if exists "monitor_snapshots anon read" on monitor_snapshots;
+create policy "monitor_snapshots anon read"
+  on monitor_snapshots
+  for select
+  to anon, authenticated
+  using (true);


### PR DESCRIPTION
## Summary
Lands the monitor app + scanner script on `main` so the `monitor-scan` workflow (already on main) can actually run.

Cherry-pick of `5fcc8a2` from `mac-mini`. WishHistory.tsx auto-merged cleanly.

## What's in here
- Live + snapshot data sources for the dashboard (35 checks per project)
- `/api/checklist`, `/api/checklist/[slug]`, `/api/wish-data/[slug]` smart dispatch
- `scripts/scan.ts` + `npm run scan` — feeds `monitor_snapshots`
- Mobile card layout for the home table
- "Back to Monitor" + copy-to-Claude prompt buttons on the wish page
- `supabase/migrations/20260520_monitor_snapshots.sql` (already run)
- `DEPLOY.md`

## Test plan
- [ ] Merge.
- [ ] First push will trigger `monitor-scan` automatically — confirm it goes green.
- [ ] Query `monitor_snapshots` for a fresh `ran_at`.
- [ ] Refresh https://utopia-fairy-monitor-qizwmg0r8.utopiaai.my and check ranAt advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)