### PR TITLE
fix(new): wish form works on the deployed monitor (snapshot mode)

### DIFF
--- a/utopia-fairy/app/api/create-project/route.ts
+++ b/utopia-fairy/app/api/create-project/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { writeFile, mkdir } from 'fs/promises'
 import path from 'path'
+import { dataMode } from '@/lib/dataSource'
+
+function buildClaudeCommand(slug: string): string {
+  return `claude "Using @CLAUDE.md files, generate the ${slug} website. Read projects/${slug}/inputs.md for the project brief."`
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -16,6 +21,19 @@ export async function POST(request: NextRequest) {
     // Validate slug format
     if (!/^[a-z0-9-]+$/.test(slug)) {
       return NextResponse.json({ success: false, error: 'Slug must be lowercase letters, numbers, and hyphens only' }, { status: 400 })
+    }
+
+    // On the deployed monitor (snapshot mode) there is no writable projects/
+    // folder — return the Claude command for the user to run locally.
+    if (dataMode() === 'snapshot') {
+      return NextResponse.json({
+        success: true,
+        mode: 'snapshot',
+        slug,
+        projectPath: `projects/${slug}/`,
+        command: buildClaudeCommand(slug),
+        prompt,
+      })
     }
 
     // Resolve project path relative to the repo root (utopia-fairy lives at repo root)
@@ -57,8 +75,11 @@ ${assetsSection}
 
     return NextResponse.json({
       success: true,
+      mode: 'live',
+      slug,
       projectPath: `projects/${slug}/`,
       filesCount: fileNames.length,
+      command: buildClaudeCommand(slug),
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/utopia-fairy/components/GenieForm.tsx
+++ b/utopia-fairy/components/GenieForm.tsx
@@ -4,7 +4,14 @@ import { useState, useRef, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import FileUpload from './FileUpload'
 
-type FormState = 'idle' | 'submitting' | 'error'
+type FormState = 'idle' | 'submitting' | 'error' | 'snapshot-success'
+
+interface SnapshotResult {
+  slug: string
+  projectPath: string
+  command: string
+  filesCount: number
+}
 
 export default function GenieForm() {
   const [prompt, setPrompt] = useState('')
@@ -12,8 +19,17 @@ export default function GenieForm() {
   const [files, setFiles] = useState<File[]>([])
   const [state, setState] = useState<FormState>('idle')
   const [errorMsg, setErrorMsg] = useState('')
+  const [snapshotResult, setSnapshotResult] = useState<SnapshotResult | null>(null)
+  const [copied, setCopied] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const router = useRouter()
+
+  const copyCommand = async () => {
+    if (!snapshotResult) return
+    await navigator.clipboard.writeText(snapshotResult.command)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -40,12 +56,26 @@ export default function GenieForm() {
     try {
       const res = await fetch('/api/create-project', { method: 'POST', body: formData })
       const data = await res.json()
-      if (data.success) {
-        router.push(`/wish/${formattedSlug}`)
-      } else {
+      if (!data.success) {
         setState('error')
         setErrorMsg(data.error || 'Something went wrong')
+        return
       }
+      if (data.mode === 'snapshot') {
+        // Deployed monitor: no local filesystem. Show the Claude command for
+        // the user to run locally — the project folder + inputs.md will be
+        // created on their machine by Claude Code.
+        setSnapshotResult({
+          slug: data.slug,
+          projectPath: data.projectPath,
+          command: data.command,
+          filesCount: 0,
+        })
+        setState('snapshot-success')
+        return
+      }
+      // Live mode: file was written, navigate to the wish page
+      router.push(`/wish/${formattedSlug}`)
     } catch {
       setState('error')
       setErrorMsg('Failed to connect to server')
@@ -53,6 +83,73 @@ export default function GenieForm() {
   }
 
   const canSubmit = prompt.trim() && slug.trim() && state !== 'submitting'
+
+  // Snapshot-mode success card — deployed monitor can't write to disk so we
+  // hand the user the Claude command to run on their machine.
+  if (state === 'snapshot-success' && snapshotResult) {
+    return (
+      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div className="uf-card" style={{
+          padding: 18,
+          background: 'var(--brand-bg)',
+          boxShadow: '0 0 0 1px var(--brand-border)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+        }}>
+          <div>
+            <span className="uf-eyebrow" style={{ color: 'var(--brand)' }}>Wish prepared</span>
+            <p style={{ color: 'var(--text-primary)', fontSize: 14, margin: '6px 0 0', lineHeight: 1.55 }}>
+              The deployed monitor can't create folders on your machine. Copy this command and paste it into Claude Code (running in the <code style={{ background: 'var(--bg-input)', padding: '1px 6px', borderRadius: 4 }}>utopia-website-builder</code> repo) — Claude will scaffold the project locally with your prompt as <code style={{ background: 'var(--bg-input)', padding: '1px 6px', borderRadius: 4 }}>{snapshotResult.projectPath}inputs.md</code>.
+            </p>
+          </div>
+          <div style={{
+            background: 'var(--bg-input)',
+            border: '1px solid var(--border-soft)',
+            borderRadius: 'var(--radius-md)',
+            padding: '12px 14px',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.55,
+            wordBreak: 'break-all',
+          }}>
+            {snapshotResult.command}
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button onClick={copyCommand} className="uf-btn-brand" style={{ padding: '8px 16px' }}>
+              {copied ? '✓ Copied' : '📋 Copy command'}
+            </button>
+            <button
+              onClick={() => {
+                setState('idle')
+                setSnapshotResult(null)
+                setPrompt('')
+                setSlug('')
+                setFiles([])
+              }}
+              style={{
+                background: 'transparent',
+                color: 'var(--text-muted)',
+                border: '1px solid var(--border-soft)',
+                borderRadius: 'var(--radius-pill)',
+                padding: '8px 16px',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'var(--font-sans)',
+              }}
+            >
+              Make another wish
+            </button>
+          </div>
+          <p style={{ color: 'var(--text-muted)', fontSize: 11.5, margin: 0, lineHeight: 1.5 }}>
+            After Claude finishes, push to <code>main</code> (or wait for the next hourly scan) and the new project will appear in the monitor.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 14 }}>


### PR DESCRIPTION
Deployed monitor was failing with `Failed to connect to server` when submitting the wish form, because `/api/create-project` tries to `mkdir`/`writeFile` to `projects/<slug>/` which doesn't exist (and is read-only) on Vercel.

In snapshot mode the endpoint now skips disk I/O and returns the Claude command. The form renders an inline success card with the command + a copy button — the user pastes it into their local Claude Code, Claude scaffolds the project on their machine, next hourly scan picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)