### PR TITLE
fix(deploy): self-destruct old service worker + lock down form button

### DIFF
--- a/utopia-fairy/components/GenieForm.tsx
+++ b/utopia-fairy/components/GenieForm.tsx
@@ -42,7 +42,8 @@ export default function GenieForm() {
     return value.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
   }
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e?: React.MouseEvent | React.FormEvent) => {
+    e?.preventDefault?.()
     if (!prompt.trim() || !slug.trim()) return
     setState('submitting')
     setErrorMsg('')
@@ -216,6 +217,7 @@ export default function GenieForm() {
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
         <button
+          type="button"
           className="fairy-btn"
           onClick={handleSubmit}
           disabled={!canSubmit}

--- a/utopia-fairy/components/RegisterSW.tsx
+++ b/utopia-fairy/components/RegisterSW.tsx
@@ -2,21 +2,30 @@
 
 import { useEffect } from 'react'
 
+/**
+ * The service worker is temporarily DISABLED — it caused stale-cache issues
+ * during the deploy + Vercel-auth-protection transition, where stale chunks
+ * would mask the real failure mode of POST requests.
+ *
+ * On mount, we unregister any existing SW and clear all caches so users who
+ * installed v1 get back to a clean state. We can re-enable the SW once
+ * everything is stable; until then this component is a one-shot scrubber.
+ */
 export default function RegisterSW() {
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (!('serviceWorker' in navigator)) return
-    // Defer to idle so it doesn't compete with initial paint
-    const register = () => {
-      navigator.serviceWorker.register('/sw.js').catch(() => { /* silently ignore */ })
+    const scrub = async () => {
+      try {
+        const regs = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(regs.map((r) => r.unregister().catch(() => {})))
+        if ('caches' in window) {
+          const keys = await caches.keys()
+          await Promise.all(keys.map((k) => caches.delete(k)))
+        }
+      } catch { /* ignore */ }
     }
-    type WindowWithIdle = Window & { requestIdleCallback?: (cb: () => void) => void }
-    const w = window as WindowWithIdle
-    if (typeof w.requestIdleCallback === 'function') {
-      w.requestIdleCallback(register)
-    } else {
-      window.setTimeout(register, 800)
-    }
+    scrub()
   }, [])
   return null
 }

--- a/utopia-fairy/public/sw.js
+++ b/utopia-fairy/public/sw.js
@@ -1,56 +1,31 @@
 /**
- * Utopia Wizard — minimal service worker.
+ * Self-destructing service worker.
  *
- * Goals:
- *   1. Make the app installable as a PWA on mobile + desktop.
- *   2. Cache the app shell so launches feel fast.
- *   3. Never stale-serve API data — /api/* always hits the network.
- *
- * Strategy: network-first for everything, fall back to cache only when
- * offline, and only for non-API routes.
+ * The original SW caused stale-cache problems during the Vercel auth +
+ * deployment-protection transition. This replacement unregisters itself
+ * and wipes every cache the first time a browser fetches it, so any
+ * client that registered v1 gets back to a clean state.
  */
-
-const CACHE = 'utopia-wizard-v1'
-const SHELL = [
-  '/manifest.json',
-  '/utopia-wizard-logo.png',
-  '/apple-touch-icon.png',
-  '/icon-192.png',
-]
 
 self.addEventListener('install', (event) => {
   self.skipWaiting()
-  event.waitUntil(
-    caches.open(CACHE).then((cache) => cache.addAll(SHELL).catch(() => {})),
-  )
 })
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))),
-    ).then(() => self.clients.claim()),
-  )
+  event.waitUntil((async () => {
+    try {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+    } catch { /* ignore */ }
+    try {
+      await self.registration.unregister()
+    } catch { /* ignore */ }
+    try {
+      const clients = await self.clients.matchAll({ type: 'window' })
+      for (const c of clients) c.navigate(c.url).catch(() => {})
+    } catch { /* ignore */ }
+  })())
 })
 
-self.addEventListener('fetch', (event) => {
-  const req = event.request
-  if (req.method !== 'GET') return
-  const url = new URL(req.url)
-  if (url.origin !== self.location.origin) return
-
-  // API + Next data must always be live. No caching, no offline fallback.
-  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_next/data')) return
-
-  event.respondWith(
-    fetch(req)
-      .then((res) => {
-        if (res.ok) {
-          const copy = res.clone()
-          caches.open(CACHE).then((c) => c.put(req, copy)).catch(() => {})
-        }
-        return res
-      })
-      .catch(() => caches.match(req).then((hit) => hit || caches.match('/'))),
-  )
-})
+// Don't intercept any fetches — let the network handle everything.
+self.addEventListener('fetch', () => {})


### PR DESCRIPTION
Kills the v1 service worker on any browser still holding it, drops all caches, and pins the wish-form submit button as type=button so a parent form can't trigger a native submit. Should unblock the wish-form failure on the deployed monitor.