### PR TITLE
fix(sw): inert service worker (was force-reloading clients mid-activate)

### DIFF
--- a/utopia-fairy/components/RegisterSW.tsx
+++ b/utopia-fairy/components/RegisterSW.tsx
@@ -3,29 +3,36 @@
 import { useEffect } from 'react'
 
 /**
- * The service worker is temporarily DISABLED — it caused stale-cache issues
- * during the deploy + Vercel-auth-protection transition, where stale chunks
- * would mask the real failure mode of POST requests.
- *
- * On mount, we unregister any existing SW and clear all caches so users who
- * installed v1 get back to a clean state. We can re-enable the SW once
- * everything is stable; until then this component is a one-shot scrubber.
+ * One-shot SW scrubber. Runs after the page has rendered (so React + the
+ * monitor data have loaded first), then quietly unregisters any service
+ * worker still hanging around and clears all caches. Persisted via
+ * localStorage so we only re-run when sw.js changes.
  */
 export default function RegisterSW() {
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (!('serviceWorker' in navigator)) return
+    const STAMP = 'uf-sw-scrubbed-v2'
+    if (localStorage.getItem(STAMP) === '1') return
     const scrub = async () => {
       try {
         const regs = await navigator.serviceWorker.getRegistrations()
         await Promise.all(regs.map((r) => r.unregister().catch(() => {})))
+      } catch { /* ignore */ }
+      try {
         if ('caches' in window) {
           const keys = await caches.keys()
           await Promise.all(keys.map((k) => caches.delete(k)))
         }
       } catch { /* ignore */ }
+      try { localStorage.setItem(STAMP, '1') } catch { /* private mode */ }
     }
-    scrub()
+    // Defer past initial paint so we don't interfere with data fetching
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(() => { scrub() }, { timeout: 3000 })
+    } else {
+      window.setTimeout(scrub, 1500)
+    }
   }, [])
   return null
 }

--- a/utopia-fairy/public/sw.js
+++ b/utopia-fairy/public/sw.js
@@ -1,31 +1,13 @@
 /**
- * Self-destructing service worker.
+ * Inert service worker.
  *
- * The original SW caused stale-cache problems during the Vercel auth +
- * deployment-protection transition. This replacement unregisters itself
- * and wipes every cache the first time a browser fetches it, so any
- * client that registered v1 gets back to a clean state.
+ * The previous version did too much during activate (cache wipe +
+ * unregister + force-reload of every controlled client) and that race
+ * was breaking pages mid-activation. This one does nothing — no fetch
+ * handler, no install steps, no activate steps. The client-side
+ * RegisterSW component handles the actual unregister cleanly after the
+ * page is rendered.
  */
 
-self.addEventListener('install', (event) => {
-  self.skipWaiting()
-})
-
-self.addEventListener('activate', (event) => {
-  event.waitUntil((async () => {
-    try {
-      const keys = await caches.keys()
-      await Promise.all(keys.map((k) => caches.delete(k)))
-    } catch { /* ignore */ }
-    try {
-      await self.registration.unregister()
-    } catch { /* ignore */ }
-    try {
-      const clients = await self.clients.matchAll({ type: 'window' })
-      for (const c of clients) c.navigate(c.url).catch(() => {})
-    } catch { /* ignore */ }
-  })())
-})
-
-// Don't intercept any fetches — let the network handle everything.
-self.addEventListener('fetch', () => {})
+self.addEventListener('install', () => { self.skipWaiting() })
+self.addEventListener('activate', (event) => { event.waitUntil(self.clients.claim()) })


### PR DESCRIPTION
Replaces sw.js with a no-op (only skipWaiting + clients.claim). Moves the cache-wipe + unregister to RegisterSW on the client, deferred via requestIdleCallback so it doesn't interrupt data fetching. Stamps localStorage so it only runs once.

This unblocks the 'This page couldn't load' error on iOS PWA installs and Safari clients still holding the old v1 SW.