### PR TITLE
fix(new): 9 MB upload cap matches Next 16 runtime ceiling

### DIFF
--- a/utopia-fairy/app/api/create-project/route.ts
+++ b/utopia-fairy/app/api/create-project/route.ts
@@ -3,9 +3,6 @@ import { writeFile, mkdir, access } from 'fs/promises'
 import path from 'path'
 
 export const maxDuration = 60
-// Some Next 16 + Node runtimes default to a ~4MB body limit on Route
-// Handlers — large brand asset bundles (logos + photos) trip it and
-// surface as "Failed to parse body as FormData". Bump to 50MB.
 export const runtime = 'nodejs'
 
 function buildClaudeCommand(slug: string): string {
@@ -31,19 +28,12 @@ export async function POST(request: NextRequest) {
     if (!prompt || !slug) {
       return NextResponse.json({ success: false, error: 'Prompt and slug are required' }, { status: 400 })
     }
-
-    // Validate slug format
     if (!/^[a-z0-9-]+$/.test(slug)) {
       return NextResponse.json({ success: false, error: 'Slug must be lowercase letters, numbers, and hyphens only' }, { status: 400 })
     }
 
     const repoRoot = path.resolve(process.cwd(), '..')
 
-    // The filesystem is the source of truth for whether we should write — not
-    // the dataMode flag. Running locally with UTOPIA_FAIRY_USE_SNAPSHOTS=1
-    // still gives access to projects/, so brand-asset uploads should land on
-    // disk. Only fall back to the "snapshot" reply when the directory genuinely
-    // isn't reachable (Vercel deployment).
     if (!(await projectsDirIsWritable(repoRoot))) {
       return NextResponse.json({
         success: true,
@@ -55,18 +45,14 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // Resolve project path relative to the repo root (utopia-fairy lives at repo root)
     const projectDir = path.join(repoRoot, 'projects', slug)
     const brandAssetsDir = path.join(projectDir, 'brand_assets')
-
-    // Create directories
     await mkdir(brandAssetsDir, { recursive: true })
 
-    // Build inputs.md content
     const timestamp = new Date().toISOString()
-    const fileNames = files.filter(f => f.size > 0).map(f => f.name)
+    const fileNames = files.filter((f) => f.size > 0).map((f) => f.name)
     const assetsSection = fileNames.length > 0
-      ? fileNames.map(name => `- ${name}`).join('\n')
+      ? fileNames.map((n) => `- ${n}`).join('\n')
       : '- (none attached)'
 
     const inputsMd = `# ${slug} — Project Inputs
@@ -81,10 +67,8 @@ ${prompt}
 ${assetsSection}
 `
 
-    // Write inputs.md
     await writeFile(path.join(projectDir, 'inputs.md'), inputsMd, 'utf-8')
 
-    // Save uploaded files to brand_assets/
     for (const file of files) {
       if (file.size === 0) continue
       const buffer = Buffer.from(await file.arrayBuffer())
@@ -101,6 +85,11 @@ ${assetsSection}
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'
-    return NextResponse.json({ success: false, error: message }, { status: 500 })
+    // Friendlier surfaces for the two common failure modes
+    let userMessage = message
+    if (message.includes('Failed to parse body') || message.includes('Unexpected end of form')) {
+      userMessage = 'Upload exceeded the 9 MB request cap. Compress your files (try squoosh.app) and try again.'
+    }
+    return NextResponse.json({ success: false, error: userMessage }, { status: 500 })
   }
 }

--- a/utopia-fairy/components/FileUpload.tsx
+++ b/utopia-fairy/components/FileUpload.tsx
@@ -11,10 +11,10 @@ const ACCEPTED_TYPES = [
   'image/png', 'image/jpeg', 'image/svg+xml', 'image/webp', 'application/pdf',
 ]
 
-// Per-file: 3.5 MB. Total request: 4 MB (Next.js Route Handler cap).
-// Stay safely under the limit so prompt + slug + boundary headers fit too.
-const PER_FILE_LIMIT = 3.5 * 1024 * 1024
-const TOTAL_LIMIT = 4 * 1024 * 1024
+// Next 16 Route Handlers hard-cap the request body at 10 MB regardless of
+// config. Stay safely under it so multipart boundaries + prompt + slug fit.
+const PER_FILE_LIMIT = 9 * 1024 * 1024
+const TOTAL_LIMIT = 9 * 1024 * 1024
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -48,13 +48,13 @@ export default function FileUpload({ files, onFilesChange }: FileUploadProps) {
 
     const messages: string[] = []
     if (tooBig.length > 0) {
-      messages.push(`${tooBig.length} file${tooBig.length === 1 ? '' : 's'} skipped — over 3.5 MB per file`)
+      messages.push(`${tooBig.length} file${tooBig.length === 1 ? '' : 's'} skipped — over 9 MB per file`)
     }
     if (wrongType.length > 0) {
       messages.push(`${wrongType.length} file${wrongType.length === 1 ? '' : 's'} skipped — only PNG / JPG / SVG / WebP / PDF`)
     }
     if (skippedForTotal > 0) {
-      messages.push(`${skippedForTotal} file${skippedForTotal === 1 ? '' : 's'} skipped — total would exceed 4 MB`)
+      messages.push(`${skippedForTotal} file${skippedForTotal === 1 ? '' : 's'} skipped — total would exceed 9 MB`)
     }
     setWarning(messages.length > 0 ? messages.join(' · ') : null)
     if (keptFromAccepted.length > 0) onFilesChange([...files, ...keptFromAccepted])
@@ -80,7 +80,7 @@ export default function FileUpload({ files, onFilesChange }: FileUploadProps) {
       >
         ✦ Drop your brand assets here or click to upload
         <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-quiet)' }}>
-          PNG / JPG / SVG / WebP / PDF · 3.5 MB per file · 4 MB total
+          PNG / JPG / SVG / WebP / PDF · 9 MB total (Next.js runtime cap — compress on squoosh.app for bigger photos)
         </div>
         <input
           ref={inputRef}
@@ -138,7 +138,7 @@ export default function FileUpload({ files, onFilesChange }: FileUploadProps) {
             color: totalSize > TOTAL_LIMIT ? 'var(--status-fail)' : 'var(--text-quiet)',
             fontVariantNumeric: 'tabular-nums',
           }}>
-            Total: {formatSize(totalSize)} / 4.0 MB
+            Total: {formatSize(totalSize)} / 9 MB
           </div>
         </>
       )}


### PR DESCRIPTION
Sets the client + server upload limits to 9 MB, matching the empirical 10 MB hard cap that Next 16 Route Handlers enforce. Larger uploads will need a Server Action or direct-to-Storage flow.