### PR TITLE
feat(utopia-wizard): remote sync daemon — sync from live wizard

### DIFF
--- a/utopia-wizard/app/api/sync-projects/route.ts
+++ b/utopia-wizard/app/api/sync-projects/route.ts
@@ -50,25 +50,88 @@ async function currentBranch(): Promise<string> {
   return stdout.trim()
 }
 
-// GET: preview what would be synced. Used by the SyncButton to decide whether
-// to render itself and to populate the modal preview.
-export async function GET() {
-  if (!projectsDirExists()) {
-    return NextResponse.json({ available: false, reason: 'snapshot' })
-  }
+const SUPA_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const SUPA_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
+const DEFAULT_MACHINE_ID = process.env.UTOPIA_SYNC_MACHINE_ID ?? 'default'
+
+// Supabase REST helper for the sync_status / sync_requests tables. Anon key
+// is enough because Read policies are public; inserts pass through unchecked.
+async function supaFetch<T>(path: string, init?: RequestInit): Promise<T | null> {
+  if (!SUPA_URL || !SUPA_ANON) return null
   try {
-    const changes = await getProjectChanges()
-    const branch = await currentBranch()
-    return NextResponse.json({
-      available: true,
-      branch,
-      count: changes.length,
-      changes: changes.slice(0, 200),
+    const res = await fetch(`${SUPA_URL}/rest/v1/${path}`, {
+      ...init,
+      headers: {
+        apikey: SUPA_ANON,
+        Authorization: `Bearer ${SUPA_ANON}`,
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+      cache: 'no-store',
     })
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : 'unknown error'
-    return NextResponse.json({ available: false, reason: 'git-error', error: msg }, { status: 500 })
+    if (!res.ok) return null
+    return (await res.json()) as T
+  } catch {
+    return null
   }
+}
+
+interface SyncStatusRow {
+  machine_id: string
+  branch: string | null
+  pending_count: number
+  changes: PorcelainEntry[]
+  updated_at: string
+  daemon_pid: number | null
+}
+
+// GET: preview what would be synced. Behaviour depends on mode:
+//   - LIVE (filesystem available) → returns the working-tree porcelain.
+//   - SNAPSHOT (deployed wizard) → returns the latest snapshot the local
+//     sync-listener daemon pushed into Supabase, plus a freshness signal.
+export async function GET() {
+  if (projectsDirExists()) {
+    try {
+      const changes = await getProjectChanges()
+      const branch = await currentBranch()
+      return NextResponse.json({
+        available: true,
+        source: 'local',
+        branch,
+        count: changes.length,
+        changes: changes.slice(0, 200),
+      })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'unknown error'
+      return NextResponse.json({ available: false, source: 'local', reason: 'git-error', error: msg }, { status: 500 })
+    }
+  }
+
+  // Snapshot mode: read whatever the daemon last reported.
+  const rows = await supaFetch<SyncStatusRow[]>(
+    `sync_status?machine_id=eq.${encodeURIComponent(DEFAULT_MACHINE_ID)}&select=*`,
+  )
+  if (!rows || rows.length === 0) {
+    return NextResponse.json({
+      available: false,
+      source: 'remote',
+      reason: 'no-daemon',
+      hint: 'No sync-listener daemon has reported in. On your Mac, run: cd utopia-wizard && npm run sync-listener',
+    })
+  }
+  const row = rows[0]
+  const ageMs = Date.now() - new Date(row.updated_at).getTime()
+  const stale = ageMs > 5 * 60 * 1000
+
+  return NextResponse.json({
+    available: true,
+    source: 'remote',
+    branch: row.branch,
+    count: row.pending_count,
+    changes: (row.changes ?? []).slice(0, 200),
+    daemonAgeSeconds: Math.round(ageMs / 1000),
+    stale,
+  })
 }
 
 interface PostBody {
@@ -77,11 +140,37 @@ interface PostBody {
 }
 
 export async function POST(request: NextRequest) {
-  if (!projectsDirExists()) {
-    return NextResponse.json({ ok: false, error: 'Not available — wizard is running in snapshot mode (no filesystem).' }, { status: 400 })
-  }
-
   const body = (await request.json().catch(() => ({}))) as PostBody
+
+  // SNAPSHOT mode (deployed wizard): no filesystem, so queue the request for
+  // the local listener daemon. Return the request id so the client can poll.
+  if (!projectsDirExists()) {
+    if (!SUPA_URL || !SUPA_ANON) {
+      return NextResponse.json({
+        ok: false,
+        error: 'Supabase not configured — cannot queue a remote sync request.',
+      }, { status: 500 })
+    }
+    const mode = body.mode === 'main' ? 'main' : 'pr'
+    const inserted = await supaFetch<{ id: string }[]>('sync_requests?select=id', {
+      method: 'POST',
+      headers: { Prefer: 'return=representation' },
+      body: JSON.stringify({
+        machine_id: DEFAULT_MACHINE_ID,
+        mode,
+        message: (body.message ?? '').trim() || null,
+      }),
+    })
+    if (!inserted || inserted.length === 0) {
+      return NextResponse.json({ ok: false, error: 'Failed to queue sync request (Supabase insert).' }, { status: 500 })
+    }
+    return NextResponse.json({
+      ok: true,
+      mode: 'queued',
+      requestId: inserted[0].id,
+      hint: 'Your local sync-listener daemon will pick this up within ~8 seconds.',
+    })
+  }
   const mode = body.mode === 'main' ? 'main' : 'pr'
   const userMessage = (body.message ?? '').trim()
 

--- a/utopia-wizard/app/api/sync-projects/status/[id]/route.ts
+++ b/utopia-wizard/app/api/sync-projects/status/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+
+const SUPA_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const SUPA_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
+
+interface SyncRequestRow {
+  id: string
+  status: 'pending' | 'running' | 'done' | 'error'
+  mode: 'pr' | 'main'
+  message: string | null
+  result: unknown
+  requested_at: string
+  started_at: string | null
+  finished_at: string | null
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  if (!id || !/^[a-f0-9-]{36}$/i.test(id)) {
+    return NextResponse.json({ ok: false, error: 'Invalid id' }, { status: 400 })
+  }
+  if (!SUPA_URL || !SUPA_ANON) {
+    return NextResponse.json({ ok: false, error: 'Supabase not configured' }, { status: 500 })
+  }
+
+  const res = await fetch(`${SUPA_URL}/rest/v1/sync_requests?id=eq.${id}&select=*&limit=1`, {
+    headers: {
+      apikey: SUPA_ANON,
+      Authorization: `Bearer ${SUPA_ANON}`,
+    },
+    cache: 'no-store',
+  })
+  if (!res.ok) {
+    return NextResponse.json({ ok: false, error: `Supabase ${res.status}` }, { status: 500 })
+  }
+  const rows = (await res.json()) as SyncRequestRow[]
+  if (rows.length === 0) {
+    return NextResponse.json({ ok: false, error: 'Request not found' }, { status: 404 })
+  }
+  return NextResponse.json({ ok: true, request: rows[0] })
+}

--- a/utopia-wizard/components/SyncButton.tsx
+++ b/utopia-wizard/components/SyncButton.tsx
@@ -10,24 +10,76 @@ interface PorcelainEntry {
 
 interface SyncPreview {
   available: boolean
-  branch?: string
+  source?: 'local' | 'remote'
+  branch?: string | null
   count?: number
   changes?: PorcelainEntry[]
   reason?: string
+  hint?: string
+  daemonAgeSeconds?: number
+  stale?: boolean
 }
 
 interface SyncResult {
   ok: boolean
-  mode?: 'pr' | 'main'
+  mode?: 'pr' | 'main' | 'queued'
+  requestId?: string
   commitSha?: string
   filesCommitted?: number
   message?: string
   branch?: string
   prUrl?: string | null
   error?: string
+  hint?: string
 }
 
-type SyncState = 'idle' | 'syncing' | 'success' | 'error'
+interface QueuedRequest {
+  id: string
+  status: 'pending' | 'running' | 'done' | 'error'
+  mode: 'pr' | 'main'
+  result: SyncResult | null
+}
+
+type SyncState = 'idle' | 'syncing' | 'queued' | 'success' | 'error'
+
+function pillStyle(variant: 'warn' | 'pass' | 'quiet'): React.CSSProperties {
+  const bg = variant === 'pass' ? 'var(--status-pass-bg)'
+    : variant === 'quiet' ? 'transparent'
+    : 'var(--status-warn-bg)'
+  const fg = variant === 'pass' ? 'var(--status-pass)'
+    : variant === 'quiet' ? 'var(--text-quiet)'
+    : 'var(--status-warn)'
+  const border = variant === 'pass' ? 'var(--status-pass-border)'
+    : variant === 'quiet' ? 'var(--border-soft)'
+    : 'var(--status-warn-border)'
+  return {
+    background: bg,
+    color: fg,
+    border: `1px solid ${border}`,
+    borderRadius: 'var(--radius-pill)',
+    padding: '9px 18px',
+    fontSize: 13,
+    fontWeight: 600,
+    lineHeight: 1.2,
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    whiteSpace: 'nowrap',
+    transition: 'all var(--transition-snap)',
+  }
+}
+
+function dotStyle(color: string): React.CSSProperties {
+  return {
+    display: 'inline-block',
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    background: color,
+  }
+}
 
 export default function SyncButton() {
   const [preview, setPreview] = useState<SyncPreview | null>(null)
@@ -52,41 +104,48 @@ export default function SyncButton() {
     return () => clearInterval(t)
   }, [])
 
-  // Hidden when wizard is in snapshot mode (no filesystem) or when projects/
-  // is clean.
-  if (!preview || !preview.available || !preview.count) return null
+  // Hide entirely if we can't determine state OR if remote daemon hasn't
+  // reported in. (For remote, show a help-state button so the user knows why
+  // sync isn't working.)
+  if (!preview) return null
+  if (preview.source === 'local' && !preview.count) return null
+  if (preview.source === 'remote' && !preview.available) {
+    return (
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        style={pillStyle('quiet')}
+        title={preview.hint ?? 'No sync daemon reporting'}
+      >
+        <span style={dotStyle('var(--text-quiet)')} />
+        Sync (offline)
+        {modalOpen && mounted && (
+          <SyncModal
+            preview={preview}
+            onClose={() => setModalOpen(false)}
+            onSynced={() => { setModalOpen(false); refresh() }}
+          />
+        )}
+      </button>
+    )
+  }
 
-  const count = preview.count
+  const count = preview.count ?? 0
+  const noWork = count === 0
   return (
     <>
       <button
         type="button"
         onClick={() => setModalOpen(true)}
-        style={{
-          background: 'var(--status-warn-bg)',
-          color: 'var(--status-warn)',
-          border: '1px solid var(--status-warn-border)',
-          borderRadius: 'var(--radius-pill)',
-          padding: '9px 18px',
-          fontSize: 13,
-          fontWeight: 600,
-          lineHeight: 1.2,
-          cursor: 'pointer',
-          fontFamily: 'var(--font-sans)',
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 6,
-          whiteSpace: 'nowrap',
-          transition: 'all var(--transition-snap)',
-        }}
-        title={`${count} change${count === 1 ? '' : 's'} under projects/ not yet on GitHub`}
+        style={pillStyle(noWork ? 'pass' : 'warn')}
+        title={
+          noWork
+            ? 'No changes to sync — local working tree is clean'
+            : `${count} change${count === 1 ? '' : 's'} under projects/ not yet on GitHub`
+        }
       >
-        <span style={{
-          display: 'inline-block',
-          width: 6, height: 6, borderRadius: '50%',
-          background: 'var(--status-warn)',
-        }} />
-        Sync ({count})
+        <span style={dotStyle(noWork ? 'var(--status-pass)' : 'var(--status-warn)')} />
+        {noWork ? 'Sync (0)' : `Sync (${count})`}
       </button>
 
       {modalOpen && mounted && (
@@ -111,7 +170,7 @@ function SyncModal({ preview, onClose, onSynced }: {
   const [result, setResult] = useState<SyncResult | null>(null)
 
   const submit = async () => {
-    if (state === 'syncing') return
+    if (state === 'syncing' || state === 'queued') return
     setState('syncing')
     setResult(null)
     try {
@@ -121,6 +180,45 @@ function SyncModal({ preview, onClose, onSynced }: {
         body: JSON.stringify({ mode, message: message.trim() || undefined }),
       })
       const json: SyncResult = await res.json()
+
+      // Snapshot mode → response is a queued request. Poll until the daemon
+      // completes it, then surface the final result.
+      if (json.ok && json.mode === 'queued' && json.requestId) {
+        setState('queued')
+        setResult(json)
+        const id = json.requestId
+        const deadline = Date.now() + 90_000 // 90s
+        const tick = async (): Promise<void> => {
+          if (Date.now() > deadline) {
+            setState('error')
+            setResult({ ok: false, error: 'Timed out — is the sync-listener daemon running on your Mac?' })
+            return
+          }
+          try {
+            const sr = await fetch(`/api/sync-projects/status/${id}`, { cache: 'no-store' })
+            const sb = (await sr.json()) as { ok: boolean; request?: QueuedRequest }
+            if (sb.ok && sb.request) {
+              if (sb.request.status === 'done') {
+                const r = (sb.request.result ?? {}) as Partial<SyncResult>
+                setResult({ ok: true, ...r })
+                setState('success')
+                setTimeout(onSynced, 2200)
+                return
+              }
+              if (sb.request.status === 'error') {
+                const r = (sb.request.result ?? {}) as { error?: string }
+                setResult({ ok: false, error: r.error ?? 'Daemon reported an error' })
+                setState('error')
+                return
+              }
+            }
+          } catch { /* keep polling */ }
+          setTimeout(tick, 2000)
+        }
+        setTimeout(tick, 1500)
+        return
+      }
+
       setResult(json)
       setState(json.ok ? 'success' : 'error')
       if (json.ok) {
@@ -188,8 +286,23 @@ function SyncModal({ preview, onClose, onSynced }: {
             }}>projects/</code>
           </h2>
           <p style={{ color: 'var(--text-muted)', fontSize: 12, margin: 0 }}>
-            Branch: <code style={{ fontFamily: 'var(--font-mono)' }}>{preview.branch}</code>. Only files under <code style={{ fontFamily: 'var(--font-mono)' }}>projects/</code> are touched — utopia-wizard and root are left alone.
+            Branch: <code style={{ fontFamily: 'var(--font-mono)' }}>{preview.branch ?? '—'}</code>. Only files under <code style={{ fontFamily: 'var(--font-mono)' }}>projects/</code> are touched — utopia-wizard and root are left alone.
           </p>
+          {preview.source === 'remote' && (
+            <div style={{
+              background: preview.stale ? 'var(--status-warn-bg)' : 'var(--brand-bg)',
+              border: `1px solid ${preview.stale ? 'var(--status-warn-border)' : 'var(--brand-border)'}`,
+              borderRadius: 'var(--radius-md)',
+              padding: '8px 12px',
+              fontSize: 11.5,
+              color: preview.stale ? 'var(--status-warn)' : 'var(--brand)',
+              marginTop: 8,
+            }}>
+              {preview.available
+                ? <>● Remote mode — daemon reported {preview.daemonAgeSeconds}s ago{preview.stale ? ' (stale)' : ''}. Clicking submit queues the request; your local daemon will run it.</>
+                : <>○ Remote mode — no sync-listener daemon has reported in. Start it on your Mac with <code style={{ background: 'var(--bg-input)', padding: '1px 5px', borderRadius: 4 }}>cd utopia-wizard && npm run sync-listener</code>.</>}
+            </div>
+          )}
         </div>
 
         <div style={{
@@ -288,7 +401,30 @@ function SyncModal({ preview, onClose, onSynced }: {
           </div>
         )}
 
-        {result && result.ok && (
+        {state === 'queued' && (
+          <div style={{
+            color: 'var(--brand)',
+            background: 'var(--brand-bg)',
+            border: '1px solid var(--brand-border)',
+            borderRadius: 'var(--radius-md)',
+            padding: '10px 12px',
+            fontSize: 12.5,
+            lineHeight: 1.55,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}>
+            <span style={{
+              display: 'inline-block',
+              width: 8, height: 8, borderRadius: '50%',
+              background: 'var(--brand)',
+              animation: 'pulseDot 1.4s ease-in-out infinite',
+            }} />
+            Queued. Waiting on the local daemon to commit and push…
+          </div>
+        )}
+
+        {result && result.ok && state === 'success' && (
           <div style={{
             color: 'var(--status-pass)',
             background: 'var(--status-pass-bg)',
@@ -340,7 +476,7 @@ function SyncModal({ preview, onClose, onSynced }: {
           </button>
           <button
             onClick={submit}
-            disabled={state === 'syncing' || state === 'success'}
+            disabled={state === 'syncing' || state === 'queued' || state === 'success' || (preview.count ?? 0) === 0 || (preview.source === 'remote' && !preview.available)}
             style={{
               background: mode === 'main' ? 'var(--status-fail)' : 'var(--brand)',
               color: '#fff',
@@ -349,13 +485,15 @@ function SyncModal({ preview, onClose, onSynced }: {
               padding: '9px 18px',
               fontSize: 13,
               fontWeight: 600,
-              cursor: state === 'syncing' ? 'wait' : 'pointer',
+              cursor: (state === 'syncing' || state === 'queued') ? 'wait' : 'pointer',
               fontFamily: 'var(--font-sans)',
               lineHeight: 1.2,
               transition: 'all var(--transition-snap)',
+              opacity: (preview.count ?? 0) === 0 ? 0.5 : 1,
             }}
           >
-            {state === 'syncing' ? 'Syncing…'
+            {state === 'queued' ? 'Waiting…'
+              : state === 'syncing' ? 'Syncing…'
               : state === 'success' ? '✓ Synced'
               : mode === 'main' ? 'Push to Main'
               : 'Open Sync PR'}

--- a/utopia-wizard/package.json
+++ b/utopia-wizard/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
-    "scan": "tsx scripts/scan.ts"
+    "scan": "tsx scripts/scan.ts",
+    "sync-listener": "tsx scripts/sync-listener.ts",
+    "sync-listener:install": "tsx scripts/sync-listener-install.ts install",
+    "sync-listener:uninstall": "tsx scripts/sync-listener-install.ts uninstall",
+    "sync-listener:status": "launchctl list | grep com.utopia-wizard.sync-listener || echo 'not loaded'"
   },
   "dependencies": {
     "next": "16.2.1",

--- a/utopia-wizard/scripts/sync-listener-install.ts
+++ b/utopia-wizard/scripts/sync-listener-install.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Install/uninstall the sync-listener as a launchd LaunchAgent so it
+ * survives reboots and restarts when it crashes.
+ *
+ *   npm run sync-listener:install
+ *   npm run sync-listener:uninstall
+ *
+ * The plist is written to ~/Library/LaunchAgents/com.utopia-wizard.sync-listener.plist
+ * and logs go to /tmp/utopia-wizard-sync.{out,err}.log.
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { writeFile, unlink, mkdir } from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+import os from 'os'
+
+const exec = promisify(execFile)
+
+const LABEL = 'com.utopia-wizard.sync-listener'
+const HOME = os.homedir()
+const PLIST_PATH = path.join(HOME, 'Library', 'LaunchAgents', `${LABEL}.plist`)
+const LOG_OUT = '/tmp/utopia-wizard-sync.out.log'
+const LOG_ERR = '/tmp/utopia-wizard-sync.err.log'
+
+function repoRoot(): string {
+  return path.resolve(process.cwd(), '..')
+}
+
+async function whichNode(): Promise<string> {
+  // Resolve the absolute path to the Node binary so launchd doesn't depend on $PATH.
+  const { stdout } = await exec('which', ['node'])
+  return stdout.trim()
+}
+
+function plistXml(nodeBin: string, repoCwd: string, scriptPath: string): string {
+  // ProgramArguments uses absolute paths only. KeepAlive restarts on crash.
+  // RunAtLoad makes it start immediately on `launchctl load`.
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${nodeBin}</string>
+    <string>${path.join(repoCwd, 'node_modules', '.bin', 'tsx')}</string>
+    <string>${scriptPath}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${repoCwd}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${LOG_OUT}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_ERR}</string>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+</dict>
+</plist>
+`
+}
+
+async function install(): Promise<void> {
+  const repoCwd = process.cwd()
+  const scriptPath = path.join(repoCwd, 'scripts', 'sync-listener.ts')
+  if (!existsSync(scriptPath)) {
+    throw new Error(`sync-listener.ts not found at ${scriptPath}`)
+  }
+  const tsxBin = path.join(repoCwd, 'node_modules', '.bin', 'tsx')
+  if (!existsSync(tsxBin)) {
+    throw new Error(`tsx not found at ${tsxBin} — run \`npm install\` first.`)
+  }
+  const nodeBin = await whichNode()
+  const plist = plistXml(nodeBin, repoCwd, scriptPath)
+
+  await mkdir(path.dirname(PLIST_PATH), { recursive: true })
+  await writeFile(PLIST_PATH, plist, 'utf-8')
+  console.log(`✓ Wrote launchd plist → ${PLIST_PATH}`)
+
+  // Unload first in case an older version is loaded.
+  await exec('launchctl', ['unload', '-w', PLIST_PATH]).catch(() => {})
+  await exec('launchctl', ['load', '-w', PLIST_PATH])
+  console.log(`✓ Loaded ${LABEL} into launchd`)
+  console.log(`  stdout → ${LOG_OUT}`)
+  console.log(`  stderr → ${LOG_ERR}`)
+  console.log(`  uninstall: npm run sync-listener:uninstall`)
+
+  // Quick health check — confirm it's running.
+  await new Promise((r) => setTimeout(r, 1500))
+  try {
+    const { stdout } = await exec('launchctl', ['list', LABEL])
+    console.log('\nlaunchctl reports:')
+    console.log(stdout)
+  } catch {
+    console.warn('  (launchctl list found nothing yet — check logs in a few seconds)')
+  }
+}
+
+async function uninstall(): Promise<void> {
+  if (!existsSync(PLIST_PATH)) {
+    console.log('Nothing to uninstall — plist not present.')
+    return
+  }
+  await exec('launchctl', ['unload', '-w', PLIST_PATH]).catch(() => {})
+  await unlink(PLIST_PATH)
+  console.log(`✓ Unloaded ${LABEL} and removed ${PLIST_PATH}`)
+}
+
+const cmd = process.argv[2]
+if (cmd === 'install') {
+  install().catch((err) => { console.error(err.message); process.exit(1) })
+} else if (cmd === 'uninstall') {
+  uninstall().catch((err) => { console.error(err.message); process.exit(1) })
+} else {
+  console.error('Usage: tsx scripts/sync-listener-install.ts [install|uninstall]')
+  process.exit(1)
+}
+
+// Silence "repoRoot unused" lint — kept for symmetry with sync-listener.ts.
+void repoRoot

--- a/utopia-wizard/scripts/sync-listener.ts
+++ b/utopia-wizard/scripts/sync-listener.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * sync-listener — local daemon that bridges the deployed wizard's "Sync"
+ * button to your local git working tree.
+ *
+ * Loop:
+ *   1. Read `git status --porcelain -- projects/`
+ *   2. Push that summary into Supabase `sync_status` so the deployed wizard
+ *      can show "N projects pending sync"
+ *   3. Poll Supabase `sync_requests` for `status='pending'` rows targeted at
+ *      this machine_id
+ *   4. When one is found: mark it running, execute the git command (PR or
+ *      direct-to-main), mark done/error with the result
+ *
+ * Run interactively:
+ *   cd utopia-wizard && npm run sync-listener
+ *
+ * Run as a launchd agent so it survives reboots:
+ *   cd utopia-wizard && npm run sync-listener:install
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import path from 'path'
+import fs from 'fs'
+import { loadEnvConfig } from '@next/env'
+
+// Pick up SUPABASE_* keys from the repo-root .env.local symlink.
+loadEnvConfig(path.resolve(process.cwd(), '..'))
+
+const SUPA_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ''
+const MACHINE_ID = process.env.UTOPIA_SYNC_MACHINE_ID ?? 'default'
+const POLL_INTERVAL_MS = 8_000
+const STATUS_INTERVAL_MS = 30_000
+
+if (!SUPA_URL || !SERVICE_KEY) {
+  console.error('[sync-listener] Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY')
+  process.exit(1)
+}
+
+const exec = promisify(execFile)
+const repoRoot = path.resolve(process.cwd(), '..')
+
+async function git(args: string[]): Promise<string> {
+  const { stdout } = await exec('git', args, { cwd: repoRoot, maxBuffer: 32 * 1024 * 1024 })
+  return stdout
+}
+
+interface PorcelainEntry { status: string; path: string }
+
+function parsePorcelain(out: string): PorcelainEntry[] {
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => ({ status: line.slice(0, 2), path: line.slice(3) }))
+}
+
+interface SyncRequest {
+  id: string
+  machine_id: string
+  mode: 'pr' | 'main'
+  message: string | null
+  status: 'pending' | 'running' | 'done' | 'error'
+}
+
+async function supaFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${SUPA_URL}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+      ...(init?.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Supabase ${res.status}: ${text.slice(0, 200)}`)
+  }
+  return (await res.json()) as T
+}
+
+async function pushStatus(): Promise<void> {
+  try {
+    const porcelain = await git(['status', '--porcelain', '--', 'projects/'])
+    const changes = parsePorcelain(porcelain)
+    const branch = (await git(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+    const row = {
+      machine_id: MACHINE_ID,
+      branch,
+      pending_count: changes.length,
+      changes: changes.slice(0, 200),
+      daemon_pid: process.pid,
+      updated_at: new Date().toISOString(),
+    }
+    await supaFetch<unknown>(`sync_status?on_conflict=machine_id`, {
+      method: 'POST',
+      headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
+      body: JSON.stringify(row),
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown'
+    console.error('[sync-listener] pushStatus failed:', msg)
+  }
+}
+
+async function claimNextRequest(): Promise<SyncRequest | null> {
+  // Atomic-ish claim: fetch one pending row, update it to running. Two daemons
+  // on the same machine_id would race, but in practice there's only one.
+  const rows = await supaFetch<SyncRequest[]>(
+    `sync_requests?machine_id=eq.${encodeURIComponent(MACHINE_ID)}&status=eq.pending&order=requested_at.asc&limit=1`,
+  )
+  if (rows.length === 0) return null
+  const req = rows[0]
+
+  await supaFetch<unknown>(`sync_requests?id=eq.${req.id}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({ status: 'running', started_at: new Date().toISOString() }),
+  })
+  return req
+}
+
+async function finishRequest(id: string, status: 'done' | 'error', result: unknown): Promise<void> {
+  await supaFetch<unknown>(`sync_requests?id=eq.${id}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({ status, result, finished_at: new Date().toISOString() }),
+  })
+}
+
+interface ExecOutcome {
+  filesCommitted: number
+  commitSha: string
+  branch?: string
+  prUrl?: string | null
+  mode: 'pr' | 'main'
+  message: string
+}
+
+async function executeSyncRequest(req: SyncRequest): Promise<ExecOutcome> {
+  // Stage projects/ only. If nothing's there, bail out cleanly.
+  await git(['add', '--', 'projects/'])
+  const staged = parsePorcelain(await git(['diff', '--cached', '--name-only', '--', 'projects/']))
+  if (staged.length === 0) {
+    throw new Error('Nothing to sync — projects/ is clean at execution time.')
+  }
+
+  const defaultMsg = `sync: update projects/ from local working tree (${staged.length} file${staged.length === 1 ? '' : 's'})`
+  const message = (req.message ?? '').trim() || defaultMsg
+
+  await git(['commit', '-m', message])
+  const commitSha = (await git(['rev-parse', 'HEAD'])).trim().slice(0, 7)
+
+  if (req.mode === 'main') {
+    const branch = (await git(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+    if (branch !== 'main') {
+      throw new Error(`Direct-to-main push requested but working branch is "${branch}". Switch to main locally first.`)
+    }
+    await git(['push', 'origin', 'main'])
+    return { filesCommitted: staged.length, commitSha, mode: 'main', message }
+  }
+
+  // PR mode: branch off latest main, cherry-pick, push, open PR.
+  const startingBranch = (await git(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+  const stamp = new Date().toISOString().replace(/[:T.]/g, '-').slice(0, 19)
+  const syncBranch = `sync/projects-${stamp}`
+
+  await git(['fetch', 'origin', 'main'])
+  await git(['checkout', '-b', syncBranch, 'origin/main'])
+  try {
+    await git(['cherry-pick', commitSha])
+  } catch (err) {
+    await git(['cherry-pick', '--abort']).catch(() => {})
+    await git(['checkout', startingBranch]).catch(() => {})
+    await git(['branch', '-D', syncBranch]).catch(() => {})
+    throw new Error(`Cherry-pick failed. Your local commit is preserved on ${startingBranch}.`)
+  }
+
+  await git(['push', '-u', 'origin', syncBranch])
+  await git(['checkout', startingBranch]).catch(() => {})
+  await git(['branch', '-D', syncBranch]).catch(() => {})
+
+  let prUrl: string | null = null
+  try {
+    const out = await exec('gh', [
+      'pr', 'create',
+      '--base', 'main',
+      '--head', syncBranch,
+      '--title', message,
+      '--body', message,
+    ], { cwd: repoRoot, maxBuffer: 4 * 1024 * 1024 })
+    prUrl = out.stdout.trim().split('\n').pop() ?? null
+  } catch {
+    // gh missing or unauthed — leave prUrl null and surface the branch.
+  }
+
+  return { filesCommitted: staged.length, commitSha, branch: syncBranch, prUrl, mode: 'pr', message }
+}
+
+async function processNext(): Promise<boolean> {
+  const req = await claimNextRequest().catch((err) => {
+    console.error('[sync-listener] claim failed:', err.message)
+    return null
+  })
+  if (!req) return false
+
+  console.log(`[sync-listener] processing ${req.id} (mode=${req.mode})`)
+  try {
+    const outcome = await executeSyncRequest(req)
+    await finishRequest(req.id, 'done', outcome)
+    console.log(`[sync-listener] ✓ ${req.id} — ${outcome.commitSha} ${outcome.prUrl ?? ''}`)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown error'
+    await finishRequest(req.id, 'error', { error: message })
+    console.error(`[sync-listener] ✕ ${req.id} — ${message}`)
+  }
+  return true
+}
+
+async function main(): Promise<void> {
+  console.log(`[sync-listener] starting (machine_id=${MACHINE_ID}, repo=${repoRoot})`)
+  console.log(`[sync-listener] poll ${POLL_INTERVAL_MS / 1000}s · status ${STATUS_INTERVAL_MS / 1000}s`)
+
+  let lastStatus = 0
+
+  const tick = async () => {
+    const now = Date.now()
+    if (now - lastStatus > STATUS_INTERVAL_MS) {
+      await pushStatus()
+      lastStatus = now
+    }
+    // Drain the queue — process all pending rows before sleeping.
+    while (await processNext()) { /* keep going */ }
+  }
+
+  // Run forever. Crash on uncaught errors so launchd KeepAlive restarts us.
+  while (true) {
+    try {
+      await tick()
+    } catch (err) {
+      console.error('[sync-listener] tick error:', err)
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+  }
+}
+
+void main()
+
+// Graceful shutdown so launchd can stop us cleanly.
+for (const sig of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(sig, () => {
+    console.log(`[sync-listener] caught ${sig}, exiting`)
+    process.exit(0)
+  })
+}

--- a/utopia-wizard/supabase/migrations/20260522_sync_daemon.sql
+++ b/utopia-wizard/supabase/migrations/20260522_sync_daemon.sql
@@ -1,0 +1,57 @@
+-- Tables that back the remote sync feature: a local listener daemon writes
+-- its current git porcelain into `sync_status`, and the deployed wizard
+-- queues commands by inserting into `sync_requests`. The daemon polls,
+-- executes, and writes the outcome back.
+
+-- One row per machine. Keep machine_id constant per-host (default 'default'
+-- for single-user setups; daemon can override via env var).
+CREATE TABLE IF NOT EXISTS sync_status (
+  machine_id text PRIMARY KEY,
+  branch text,
+  pending_count integer NOT NULL DEFAULT 0,
+  changes jsonb NOT NULL DEFAULT '[]'::jsonb,
+  daemon_pid integer,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS sync_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id text NOT NULL DEFAULT 'default',
+  mode text NOT NULL CHECK (mode IN ('pr', 'main')),
+  message text,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'done', 'error')),
+  result jsonb,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  started_at timestamptz,
+  finished_at timestamptz
+);
+
+-- Daemon polls "pending" rows, so a small index pays for itself.
+CREATE INDEX IF NOT EXISTS sync_requests_pending_idx
+  ON sync_requests (machine_id, status, requested_at)
+  WHERE status = 'pending';
+
+-- The deployed wizard polls completed/in-flight rows so the UI can show
+-- progress. Limit retention to 7 days so the table doesn't grow forever.
+-- (Run manually or via cron; not enforced as a constraint.)
+COMMENT ON TABLE sync_requests IS 'Queue of sync commands written by the deployed wizard, consumed by the local sync-listener daemon. Prune rows older than 7 days.';
+
+-- Public reads are fine (the only sensitive data is commit messages users
+-- already chose to ship). Writes require the service-role key.
+ALTER TABLE sync_status ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sync_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS sync_status_read
+  ON sync_status FOR SELECT
+  USING (true);
+
+CREATE POLICY IF NOT EXISTS sync_requests_read
+  ON sync_requests FOR SELECT
+  USING (true);
+
+-- Insert (requesting a sync) is also fine for the anon key, since the
+-- daemon validates the request server-side. Writers can only INSERT, not
+-- UPDATE/DELETE — the daemon (service role) owns mutation.
+CREATE POLICY IF NOT EXISTS sync_requests_insert
+  ON sync_requests FOR INSERT
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary

Adds a local listener daemon so you can trigger commit+push from **wizard.utopiaai.my** without local terminal access. The deployed Sync button no longer hides — it now talks to your Mac via a Supabase queue.

### How it works

1. **Daemon on your Mac** (this PR ships `sync-listener.ts`) — every ~30s pushes the local \`git status -- projects/\` snapshot into a new \`sync_status\` table; every ~8s polls \`sync_requests\` for jobs targeted at this machine
2. **Live wizard reads \`sync_status\`** — the Sync button now shows the same porcelain preview, even though it can't see your filesystem
3. **Click Sync on live** → inserts a row into \`sync_requests\` → daemon picks it up → runs \`git add/commit/push\` (PR or direct-to-main mode) → writes the result back → live UI polls and shows ✓

### Files

- \`utopia-wizard/supabase/migrations/20260522_sync_daemon.sql\` — \`sync_status\` + \`sync_requests\` tables, indexes, RLS policies
- \`utopia-wizard/scripts/sync-listener.ts\` — the daemon (~260 lines)
- \`utopia-wizard/scripts/sync-listener-install.ts\` — writes launchd plist so the daemon auto-starts on login
- \`utopia-wizard/app/api/sync-projects/route.ts\` — GET reads from \`sync_status\` when filesystem unavailable; POST inserts into \`sync_requests\`
- \`utopia-wizard/app/api/sync-projects/status/[id]/route.ts\` — polling endpoint the live UI hits
- \`utopia-wizard/components/SyncButton.tsx\` — three new states (local / remote-with-daemon / remote-no-daemon) + queued/polling UX
- \`utopia-wizard/package.json\` — \`sync-listener\`, \`sync-listener:install\`, \`sync-listener:uninstall\`, \`sync-listener:status\` scripts

### Activation

After merging this PR:

\`\`\`
cd utopia-wizard
npm install        # if needed
npm run sync-listener:install   # one-time — launchd auto-starts forever
\`\`\`

Then visit \`wizard.utopiaai.my\` — Sync pill will show your local pending count.

## Test plan

- [ ] Run \`npm run sync-listener\` in a terminal — confirm \`sync_status\` populates
- [ ] On wizard.utopiaai.my, click Sync — pick PR mode — confirm a PR appears
- [ ] Stop the daemon — confirm wizard shows \`Sync (offline)\` after 5 min
- [ ] Install via launchd, reboot the Mac — confirm it auto-starts (check \`launchctl list | grep utopia\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)