### PR TITLE
fix(sync-listener): handle empty Supabase response on return=minimal

### DIFF
--- a/utopia-wizard/app/api/sync-projects/route.ts
+++ b/utopia-wizard/app/api/sync-projects/route.ts
@@ -70,7 +70,9 @@ async function supaFetch<T>(path: string, init?: RequestInit): Promise<T | null>
       cache: 'no-store',
     })
     if (!res.ok) return null
-    return (await res.json()) as T
+    const text = await res.text()
+    if (!text) return null
+    return JSON.parse(text) as T
   } catch {
     return null
   }

--- a/utopia-wizard/scripts/sync-listener.ts
+++ b/utopia-wizard/scripts/sync-listener.ts
@@ -79,7 +79,11 @@ async function supaFetch<T>(path: string, init?: RequestInit): Promise<T> {
     const text = await res.text().catch(() => '')
     throw new Error(`Supabase ${res.status}: ${text.slice(0, 200)}`)
   }
-  return (await res.json()) as T
+  // Supabase returns 204 No Content when Prefer=return=minimal — there's no
+  // body to parse. Read raw text first; only JSON.parse if non-empty.
+  const text = await res.text()
+  if (!text) return undefined as unknown as T
+  return JSON.parse(text) as T
 }
 
 async function pushStatus(): Promise<void> {


### PR DESCRIPTION
The supaFetch helpers in both the daemon and the API route called `res.json()` unconditionally, but Supabase returns an empty body when the request includes `Prefer=return=minimal`. `.json()` on an empty string throws "Unexpected end of JSON input", which silently killed every `pushStatus()` / claim* call — daemon stayed alive but produced no logs and no Supabase writes.

Fix: read `res.text()` first; only `JSON.parse` when non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)