### PR TITLE
fix(tablechair): point deploy-url.txt at alias serving new code

### DIFF
--- a/projects/tablechair-rental-malaysia/deploy-url.txt
+++ b/projects/tablechair-rental-malaysia/deploy-url.txt
@@ -1,1 +1,1 @@
-https://tablechair-rental-malaysia.vercel.app
+https://tablechair-rental-malaysia.utopiaai.my


### PR DESCRIPTION
The `.vercel.app` URL was still routing to an older deployment without webcore, so the cron's `live-db-connected` probe got the fallback phone. The `.utopiaai.my` alias resolves to the latest production deploy and returns the DB phone correctly.

Verified: `wa.me/60178799468` on `https://tablechair-rental-malaysia.utopiaai.my/en/redirect-whatsapp-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)