### PR TITLE
fix(tracking): repoint data-website at live aliases + add reachability check

### DIFF
--- a/projects/electrician-24-hour/app/[locale]/layout.tsx
+++ b/projects/electrician-24-hour/app/[locale]/layout.tsx
@@ -59,7 +59,7 @@ export default async function LocaleLayout({
         <script
           defer
           src="https://webcore.utopiaai.my/t.js"
-          data-website="electrician-24-hour.utopiaai.my"
+          data-website="electrician-24hour.utopiaai.my"
         />
       </head>
       <body style={{ fontFamily: 'var(--font-inter), Inter, sans-serif' }}>

--- a/projects/oxihome-malaysia/app/[locale]/layout.tsx
+++ b/projects/oxihome-malaysia/app/[locale]/layout.tsx
@@ -101,7 +101,7 @@ export default async function LocaleLayout({ children, params }: Props) {
         <link rel="alternate" hrefLang="ms" href={`${siteConfig.siteUrl}/ms`} />
         <link rel="alternate" hrefLang="zh" href={`${siteConfig.siteUrl}/zh`} />
         <link rel="alternate" hrefLang="x-default" href={`${siteConfig.siteUrl}/en`} />
-              <script defer src="https://utopia-webcore.vercel.app/t.js" data-website="oxihome-malaysia.vercel.app"></script>
+              <script defer src="https://webcore.utopiaai.my/t.js" data-website="oxihome-malaysia.utopiaai.my"></script>
       </head>
       <body className="antialiased" style={{ fontFamily: 'var(--font-body)', color: 'var(--brand-text)', background: 'var(--brand-white)' }}>
         <NextIntlClientProvider messages={messages}>

--- a/utopia-wizard/lib/checklist.ts
+++ b/utopia-wizard/lib/checklist.ts
@@ -312,6 +312,30 @@ const TRACKING: Check[] = [
     },
   },
   {
+    // Catches typos & broken aliases that `data-website-match` lets through.
+    // Example: `data-website="electrician-24-hour.utopiaai.my"` (with extra
+    // dash) matches the auto-derived alias but DNS doesn't resolve — every
+    // tracker event lands in a bucket nobody is watching.
+    group: 'Tracking', id: 'data-website-reachable', name: 'data-website resolves to a live URL',
+    run: async (ctx) => {
+      const c = await readProjectFile(ctx, 'app/[locale]/layout.tsx')
+      if (!c) return fail('data-website-reachable', 'data-website resolves to a live URL', 'layout.tsx missing')
+      const m = c.match(/data-website=["']([^"']+)["']/)
+      if (!m) return fail('data-website-reachable', 'data-website resolves to a live URL', 'no data-website attribute on tracking script')
+      const dw = m[1]
+      const url = `https://${dw}`
+      try {
+        const res = await fetch(url, { method: 'HEAD', redirect: 'manual', signal: AbortSignal.timeout(5000) })
+        if (res.ok || (res.status >= 300 && res.status < 400)) {
+          return pass('data-website-reachable', 'data-website resolves to a live URL', dw)
+        }
+        return fail('data-website-reachable', 'data-website resolves to a live URL', `${url} returned ${res.status} — events will land in a dead bucket`)
+      } catch {
+        return fail('data-website-reachable', 'data-website resolves to a live URL', `${url} unreachable — events will land in a dead bucket`)
+      }
+    },
+  },
+  {
     group: 'Tracking', id: 'uwc-typedef', name: 'window.uwc type declaration',
     run: async (ctx) => {
       const c = await readProjectFile(ctx, 'global.d.ts')


### PR DESCRIPTION
## Bug

The `data-website-match` check accepted any string matching either `siteConfig.domain` or its auto-derived `.utopiaai.my` alias. That let two real bugs slip through:

- **electrician-24-hour**: `data-website="electrician-24-hour.utopiaai.my"` (extra dash before 24) — DNS doesn't resolve. Every `uwc()` event was landing in a bucket nobody was watching. Now `electrician-24hour.utopiaai.my` (the alias Vercel actually serves).
- **oxihome-malaysia**: `data-website="oxihome-malaysia.vercel.app"` — returns HTTP 404. Real traffic is on `.utopiaai.my`. Switched to the working alias. Also flipped the script src from the legacy `utopia-webcore.vercel.app/t.js` to the canonical `webcore.utopiaai.my/t.js`.

## New check

`data-website-reachable` (Tracking group) probes `https://<data-website>` with HEAD and fails if HTTP 4xx/5xx. Catches typos and broken aliases that the spelling-only match misses.

## Test plan

- [ ] After merge: Rescan Now. electrician + oxihome both gain the new check passing.
- [ ] Confirm webcore admin starts seeing events for both sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)