### PR TITLE
fix(electrician): deploy-url.txt → utopiaai.my alias

### DIFF
--- a/projects/electrician-24-hour/deploy-url.txt
+++ b/projects/electrician-24-hour/deploy-url.txt
@@ -1,1 +1,1 @@
-https://electrician-24-hour.vercel.app
+https://electrician-24hour.utopiaai.my


### PR DESCRIPTION
Aligns deploy-url.txt with the .utopiaai.my alias that the layout's data-website points to. Without this, the data-website-match check fails because the deploy-url host doesn't match the bucket key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)