### PR TITLE
fix(sewa-motor): Layout & Design chrome + translation keys

### DIFF
--- a/projects/sewa-motor-malaysia/.gitignore
+++ b/projects/sewa-motor-malaysia/.gitignore
@@ -1,1 +1,3 @@
 .vercel
+brand_assets/
+temporary screenshots/

--- a/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
@@ -241,10 +241,10 @@ export default function HomePageClient() {
                   <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide text-white" style={{ background: 'rgba(255,107,53,0.2)', border: '1px solid rgba(255,107,53,0.3)' }}>Same-Day Delivery</span>
                   <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide text-white" style={{ background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)' }}>128 Cities</span>
                 </div>
-                <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-white mb-4" style={{ letterSpacing: '-0.03em', lineHeight: '1.1' }}>
+                <h2 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-white mb-4" style={{ letterSpacing: '-0.03em', lineHeight: '1.1' }}>
                   Motor Rental Malaysia —{' '}
                   <span className="gradient-text">Sewa Motor from RM30/day</span>
-                </h1>
+                </h2>
                 <p className="text-sm md:text-base font-normal mb-6" style={{ color: 'rgba(255,255,255,0.7)', lineHeight: '1.75' }}>{t('hero.subheadline')}</p>
                 <a href={WA_LINK} className="wa-btn inline-flex items-center gap-2.5 px-6 py-3 rounded-xl text-base font-bold text-white" style={{ background: 'var(--wa-green)' }}>
                   <WAIcon />{t('hero.cta')}

--- a/projects/sewa-motor-malaysia/app/[locale]/blog/[slug]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/blog/[slug]/page.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link'
 import { siteConfig } from '@/config/site'
 import { getBlogPosts, getBlogPostBySlug } from '@/lib/webcore'
 import BlogLinkTracker from '@/components/tracking/BlogLinkTracker'
+import FomoBanner from '@/components/FomoBanner'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
 
 const POST_COPY = {
   en: { home: 'Home', blog: 'Blog', back: '← Back to blog', minRead: 'min read', relatedTitle: 'Related articles', ctaTitle: 'Ready to ride?', ctaBody: 'WhatsApp Sewa Motor Malaysia for same-day delivery from RM30/day.', ctaButton: 'Chat on WhatsApp' },
@@ -84,6 +87,9 @@ export default async function BlogPostPage({
   }
 
   return (
+    <>
+      <FomoBanner />
+      <SiteHeader />
     <main style={{ background: '#ffffff', minHeight: '100vh' }}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJson) }} />
 
@@ -219,5 +225,7 @@ export default async function BlogPostPage({
         <Link href={`/${locale}/blog`} style={{ fontSize: 14, color: '#64748b', textDecoration: 'none' }}>{c.back}</Link>
       </section>
     </main>
+      <SiteFooter />
+    </>
   )
 }

--- a/projects/sewa-motor-malaysia/app/[locale]/blog/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/blog/page.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link'
 import { siteConfig } from '@/config/site'
 import { getBlogPosts } from '@/lib/webcore'
 import BlogLinkTracker from '@/components/tracking/BlogLinkTracker'
+import FomoBanner from '@/components/FomoBanner'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
 
 const BLOG_COPY = {
   en: {
@@ -80,7 +83,10 @@ export default async function BlogListingPage({
   const dateLocale = locale === 'ms' ? 'ms-MY' : locale === 'zh' ? 'zh-CN' : 'en-MY'
 
   return (
-    <main style={{ minHeight: '100vh', background: '#ffffff' }}>
+    <>
+      <FomoBanner />
+      <SiteHeader />
+      <main style={{ minHeight: '100vh', background: '#ffffff' }}>
       <section
         style={{
           background: 'linear-gradient(135deg, #0f172a 0%, #1e3a8a 100%)',
@@ -214,6 +220,8 @@ export default async function BlogListingPage({
           {c.backHome}
         </Link>
       </section>
-    </main>
+      </main>
+      <SiteFooter />
+    </>
   )
 }

--- a/projects/sewa-motor-malaysia/app/[locale]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
 import { siteConfig } from '@/config/site'
 import { OrganizationSchema } from '@/components/schema/OrganizationSchema'
+import FomoBanner from '@/components/FomoBanner'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
+import MarketingMarquee from '@/components/MarketingMarquee'
+import PageStyles from '@/components/PageStyles'
 import HomePageClient from './HomePageClient'
 
 export async function generateMetadata({
@@ -12,7 +18,6 @@ export async function generateMetadata({
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: 'home.meta' })
   const url = `${siteConfig.siteUrl}/${locale}`
-
   return {
     title: t('title'),
     description: t('description'),
@@ -36,11 +41,62 @@ export async function generateMetadata({
   }
 }
 
-export default function HomePage() {
+export default async function HomePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const hero = await getTranslations({ locale, namespace: 'home.hero' })
+  const shared = await getTranslations({ locale, namespace: 'shared' })
+
   return (
     <>
       <OrganizationSchema />
+      <FomoBanner />
+      <SiteHeader />
+
+      <section className="home-hero">
+        <div
+          className="home-hero-bg"
+          role="img"
+          aria-label={hero('bgAlt')}
+        />
+        <div className="home-hero-inner">
+          <h1>{hero('headline')}</h1>
+          <h2>{hero('subheadline')}</h2>
+          <Link
+            href={`/${locale}/redirect-whatsapp-1`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="home-hero-cta"
+          >
+            {hero('cta')}
+          </Link>
+        </div>
+      </section>
+
+      <div className="usp-panel">
+        <div className="usp-cell">
+          <h3>{shared('whyChoose.title1')}</h3>
+          <p>{shared('whyChoose.desc1')}</p>
+        </div>
+        <div className="usp-cell">
+          <h3>{shared('whyChoose.title2')}</h3>
+          <p>{shared('whyChoose.desc2')}</p>
+        </div>
+        <div className="usp-cell">
+          <h3>{shared('whyChoose.title3')}</h3>
+          <p>{shared('whyChoose.desc3')}</p>
+        </div>
+      </div>
+
+      <MarketingMarquee variant="light" />
+
       <HomePageClient />
+
+      <SiteFooter />
+      <PageStyles />
     </>
   )
 }

--- a/projects/sewa-motor-malaysia/app/globals.css
+++ b/projects/sewa-motor-malaysia/app/globals.css
@@ -118,3 +118,42 @@ h1, h2, h3, h4, h5, h6 {
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
+
+/* ── Language switcher (high-specificity overrides so element resets don't
+ *    clobber the dropdown's flex layout) ─────────────────────────────────── */
+.lsw-toggle {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  flex-direction: row !important;
+}
+.lsw-item {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  flex-direction: row !important;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand-text);
+  border: 1px solid transparent;
+  background: transparent;
+  text-decoration: none;
+}
+.lsw-item:hover { background: var(--brand-primary-xs); }
+.lsw-item.is-active {
+  background: var(--brand-dark);
+  color: #fff !important;
+}
+.lsw-label { display: inline-block; line-height: 1; white-space: nowrap; }
+.lsw-flag { display: inline-block; line-height: 1; }
+.lsw-caret { opacity: 0.6; }
+
+/* ── USP panel (single container with 3 cells) ─────────────────────────── */
+.usp-panel-fallback { /* keep .usp-panel from PageStyles authoritative */ }
+
+/* ── Nav CTA mobile-hide fallback (header also enforces this) ──────────── */
+@media (max-width: 879px) {
+  .nav-cta { display: none !important; }
+}

--- a/projects/sewa-motor-malaysia/components/FomoBanner.tsx
+++ b/projects/sewa-motor-malaysia/components/FomoBanner.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+function diffParts(target: Date) {
+  const ms = Math.max(0, target.getTime() - Date.now());
+  const days = Math.floor(ms / 86_400_000);
+  const hours = Math.floor((ms % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((ms % 3_600_000) / 60_000);
+  const seconds = Math.floor((ms % 60_000) / 1000);
+  return { days, hours, minutes, seconds };
+}
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+export default function FomoBanner() {
+  const t = useTranslations('fomo');
+  const locale = useLocale();
+  const [parts, setParts] = useState<{ days: number; hours: number; minutes: number; seconds: number } | null>(null);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('sewamotor-promo-end') : null;
+    let end: Date;
+    if (stored && !Number.isNaN(Date.parse(stored)) && new Date(stored).getTime() > Date.now()) {
+      end = new Date(stored);
+    } else {
+      end = new Date(Date.now() + 7 * 86_400_000);
+      try { localStorage.setItem('sewamotor-promo-end', end.toISOString()); } catch { /* noop */ }
+    }
+    setParts(diffParts(end));
+    const id = setInterval(() => setParts(diffParts(end)), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="fomo-bar" role="region" aria-label="Promotional offer">
+      <div className="fomo-inner">
+        <span className="fomo-tag">{t('eyebrow') || 'PROMO'}</span>
+        <span className="fomo-body">{t('body') || t('message') || ''}</span>
+        <span aria-live="polite" className="fomo-clock">
+          {parts ? (
+            <>
+              <span>{pad(parts.days)}</span>
+              <span>:</span>
+              <span>{pad(parts.hours)}</span>
+              <span>:</span>
+              <span>{pad(parts.minutes)}</span>
+              <span>:</span>
+              <span>{pad(parts.seconds)}</span>
+            </>
+          ) : (
+            <span style={{ visibility: 'hidden' }}>00 : 00 : 00 : 00</span>
+          )}
+        </span>
+        <Link href={`/${locale}/redirect-whatsapp-1`} className="fomo-link" target="_blank" rel="noopener noreferrer">
+          {t('bookNow') || t('ctaLabel') || 'Book Now'} →
+        </Link>
+      </div>
+      <style jsx>{`
+        .fomo-bar { background: #B91C1C; color: #fff; font-size: 13px; padding: 8px 16px; }
+        .fomo-inner { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: center; gap: 12px; flex-wrap: wrap; }
+        .fomo-tag { font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.9; }
+        .fomo-body { font-weight: 500; }
+        .fomo-clock { font-variant-numeric: tabular-nums; font-weight: 600; }
+        .fomo-link { font-weight: 700; text-decoration: underline; }
+      `}</style>
+    </div>
+  );
+}

--- a/projects/sewa-motor-malaysia/components/MarketingMarquee.tsx
+++ b/projects/sewa-motor-malaysia/components/MarketingMarquee.tsx
@@ -1,0 +1,56 @@
+/**
+ * Scrolling marquee strip between major sections — replaces the old
+ * decorative dashed dividers. Renders the same brand phrases in a CSS-only
+ * loop (no JS animation framework dependency).
+ */
+const PHRASES = [
+  'Same-Day Delivery',
+  'From RM30/day',
+  'Honda · Yamaha · Modenas',
+  '128 Cities Nationwide',
+  'Safety-Checked Fleet',
+  '7-Day WhatsApp Support',
+];
+
+export default function MarketingMarquee({ variant = 'light' }: { variant?: 'light' | 'dark' }) {
+  // Duplicate the phrase list so the keyframe can translate -50% for a seamless loop.
+  const loop = [...PHRASES, ...PHRASES];
+  return (
+    <div className={`marquee marquee--${variant}`} aria-hidden="true">
+      <div className="marquee-track">
+        {loop.map((phrase, i) => (
+          <span className="marquee-item" key={i}>
+            <span>{phrase}</span>
+            <span className="marquee-dot">●</span>
+          </span>
+        ))}
+      </div>
+      <style>{`
+        .marquee {
+          overflow: hidden;
+          padding: 14px 0;
+          border-block: 1px solid rgba(0, 0, 0, 0.06);
+        }
+        .marquee--light { background: #FFF4EE; color: #16213E; }
+        .marquee--dark { background: #16213E; color: #fff; border-color: rgba(255,255,255,0.08); }
+        .marquee-track {
+          display: inline-flex;
+          gap: 36px;
+          padding-left: 36px;
+          animation: marquee-scroll 32s linear infinite;
+          white-space: nowrap;
+          width: max-content;
+        }
+        .marquee-item { display: inline-flex; align-items: center; gap: 36px; font-weight: 700; font-size: 14px; letter-spacing: 0.04em; text-transform: uppercase; }
+        .marquee-dot { opacity: 0.5; }
+        @keyframes marquee-scroll {
+          from { transform: translateX(0); }
+          to { transform: translateX(-50%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .marquee-track { animation: none; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/projects/sewa-motor-malaysia/components/PageStyles.tsx
+++ b/projects/sewa-motor-malaysia/components/PageStyles.tsx
@@ -1,0 +1,81 @@
+/**
+ * Shared CSS for homepage + location pages. Lives in a real component (not in
+ * globals.css) so we can drop it onto specific pages and keep route-level CSS
+ * cohesive. Add new rules here when a class is reused across the homepage
+ * hero / USP / location pages.
+ */
+export default function PageStyles() {
+  return (
+    <style>{`
+      /* Hero ─────────────────────────────────────────────────────────── */
+      .home-hero {
+        position: relative;
+        padding: 96px 24px 64px;
+        background: linear-gradient(135deg, #16213E 0%, #1A2744 60%, #0F172A 100%);
+        color: #fff;
+        overflow: hidden;
+      }
+      .home-hero-inner { max-width: 1100px; margin: 0 auto; position: relative; z-index: 1; text-align: center; }
+      .home-hero-bg {
+        position: absolute; inset: 0;
+        background-image: linear-gradient(135deg, rgba(22,33,62,0.85), rgba(15,23,42,0.95)), url('/og-image.jpg');
+        background-size: cover;
+        background-position: center;
+        opacity: 0.6;
+      }
+      .home-hero h1 {
+        font-size: clamp(30px, 4.6vw, 52px);
+        font-weight: 800;
+        margin: 0;
+        letter-spacing: -0.02em;
+        line-height: 1.1;
+      }
+      .home-hero h2 {
+        font-size: clamp(15px, 2vw, 18px);
+        font-weight: 500;
+        margin: 18px auto 26px;
+        max-width: 680px;
+        color: rgba(255,255,255,0.85);
+        line-height: 1.55;
+      }
+      .home-hero-cta {
+        display: inline-block;
+        background: #25D366; color: #fff;
+        font-weight: 700; font-size: 16px;
+        padding: 14px 30px;
+        border-radius: 999px;
+        text-decoration: none;
+      }
+
+      /* USP panel ────────────────────────────────────────────────────── */
+      .usp-panel {
+        max-width: 1100px;
+        margin: -32px auto 56px;
+        background: #fff;
+        border-radius: 18px;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12), 0 1px 3px rgba(15, 23, 42, 0.06);
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        overflow: hidden;
+        position: relative;
+        z-index: 5;
+      }
+      .usp-cell {
+        padding: 28px 22px;
+        display: flex; flex-direction: column; gap: 8px; align-items: center; text-align: center;
+        border-right: 1px solid #F1F5F9;
+      }
+      .usp-cell:last-child { border-right: none; }
+      .usp-cell h3 {
+        font-size: 15px; font-weight: 700; margin: 0; color: #16213E; letter-spacing: -0.01em;
+      }
+      .usp-cell p {
+        font-size: 13px; color: #475569; line-height: 1.5; margin: 0;
+      }
+      @media (max-width: 720px) {
+        .usp-cell { border-right: none; border-bottom: 1px solid #F1F5F9; }
+        .usp-cell:last-child { border-bottom: none; }
+      }
+    `}</style>
+  );
+}

--- a/projects/sewa-motor-malaysia/components/SiteFooter.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteFooter.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+export default function SiteFooter() {
+  const t = useTranslations('footer');
+  const nav = useTranslations('nav');
+  const locale = useLocale();
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="site-footer">
+      <div className="site-footer-inner">
+        <div className="footer-col">
+          <p className="footer-brand">Sewa Motor Malaysia</p>
+          <p className="footer-tagline">{t('tagline')}</p>
+        </div>
+        <div className="footer-col">
+          <p className="footer-heading">{t('quickLinks')}</p>
+          <Link href={`/${locale}`}>{nav('home')}</Link>
+          <Link href={`/${locale}#products`}>{nav('products')}</Link>
+          <Link href={`/${locale}/blog`}>{nav('blog')}</Link>
+        </div>
+        <div className="footer-col">
+          <p className="footer-heading">{t('topLocations')}</p>
+          <Link href={`/${locale}/sewa-motor/kuala-lumpur`}>Kuala Lumpur</Link>
+          <Link href={`/${locale}/sewa-motor/petaling-jaya`}>Petaling Jaya</Link>
+          <Link href={`/${locale}/sewa-motor/shah-alam`}>Shah Alam</Link>
+        </div>
+      </div>
+      <div className="site-footer-bar">
+        <p>{t('copyright', { year })}</p>
+      </div>
+      <style jsx>{`
+        .site-footer { background: #0F172A; color: #E2E8F0; margin-top: 64px; }
+        .site-footer-inner { max-width: 1200px; margin: 0 auto; padding: 48px 20px 24px; display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 32px; }
+        .footer-col { display: flex; flex-direction: column; gap: 10px; }
+        .footer-brand { font-weight: 800; font-size: 18px; color: #fff; margin: 0; }
+        .footer-tagline { color: #94A3B8; font-size: 14px; line-height: 1.55; margin: 0; }
+        .footer-heading { font-weight: 700; font-size: 13px; color: #fff; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 4px; }
+        .footer-col a { color: #CBD5E1; font-size: 14px; }
+        .footer-col a:hover { color: #fff; }
+        .site-footer-bar { border-top: 1px solid #1E293B; padding: 18px 20px; text-align: center; font-size: 12px; color: #94A3B8; }
+        .site-footer-bar p { margin: 0; }
+      `}</style>
+    </footer>
+  );
+}

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import LanguageSwitcher from './LanguageSwitcher';
+
+export default function SiteHeader() {
+  const t = useTranslations('nav');
+  const locale = useLocale();
+  const [open, setOpen] = useState(false);
+  const close = () => setOpen(false);
+
+  return (
+    <header className="site-header">
+      <div className="site-header-inner">
+        <Link href={`/${locale}`} className="site-brand">Sewa Motor Malaysia</Link>
+        <nav className="site-nav site-nav--desktop" aria-label="Primary">
+          <Link href={`/${locale}`}>{t('home')}</Link>
+          <Link href={`/${locale}#products`}>{t('products')}</Link>
+          <Link href={`/${locale}#calculator`}>{t('calculator')}</Link>
+          <Link href={`/${locale}#locations`}>{t('locations')}</Link>
+          <Link href={`/${locale}/blog`}>{t('blog')}</Link>
+        </nav>
+
+        <button
+          type="button"
+          className="site-burger"
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
+          aria-controls="site-nav-mobile"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+          <span aria-hidden="true" />
+        </button>
+
+        <div className="site-actions">
+          <LanguageSwitcher />
+          <Link
+            href={`/${locale}/redirect-whatsapp-1`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-cta"
+          >
+            {t('whatsappCta')}
+          </Link>
+        </div>
+      </div>
+
+      <div id="site-nav-mobile" className={`site-mobile-drawer ${open ? 'is-open' : ''}`} aria-hidden={!open}>
+        <nav className="site-mobile-nav" aria-label="Mobile primary">
+          <Link href={`/${locale}`} onClick={close}>{t('home')}</Link>
+          <Link href={`/${locale}#products`} onClick={close}>{t('products')}</Link>
+          <Link href={`/${locale}#calculator`} onClick={close}>{t('calculator')}</Link>
+          <Link href={`/${locale}#locations`} onClick={close}>{t('locations')}</Link>
+          <Link href={`/${locale}/blog`} onClick={close}>{t('blog')}</Link>
+        </nav>
+      </div>
+
+      <style jsx>{`
+        .site-header {
+          position: sticky; top: 0; z-index: 40;
+          background: rgba(255, 255, 255, 0.94);
+          backdrop-filter: saturate(180%) blur(10px);
+          -webkit-backdrop-filter: saturate(180%) blur(10px);
+          border-bottom: 1px solid #E2E8F0;
+        }
+        .site-header-inner {
+          max-width: 1200px; margin: 0 auto;
+          display: flex; align-items: center; justify-content: space-between;
+          gap: 12px; padding: 12px 20px; min-height: 60px;
+        }
+        .site-brand { font-weight: 800; font-size: 15px; color: var(--brand-dark, #16213E); white-space: nowrap; }
+        .site-nav { display: inline-flex; gap: 24px; }
+        .site-nav a { color: var(--brand-text, #1B2432); font-weight: 600; font-size: 14px; white-space: nowrap; }
+        .site-nav a:hover { color: var(--brand-primary, #FF6B35); }
+        .site-nav--desktop { display: none; }
+        .site-actions { display: inline-flex; align-items: center; gap: 10px; }
+        .nav-cta {
+          background: var(--wa-green, #25D366); color: #fff;
+          padding: 8px 14px; border-radius: 999px; font-weight: 700; font-size: 13px;
+          white-space: nowrap;
+        }
+        .site-burger { display: inline-flex; flex-direction: column; justify-content: center; gap: 4px; width: 38px; height: 38px; padding: 0 8px; background: transparent; border: 1px solid #CBD5E1; border-radius: 10px; cursor: pointer; }
+        .site-burger span { display: block; height: 2px; width: 100%; background: #16213E; border-radius: 2px; }
+        .site-mobile-drawer { display: none; background: #fff; border-top: 1px solid #E2E8F0; padding: 14px 20px 18px; }
+        .site-mobile-drawer.is-open { display: block; }
+        .site-mobile-nav { display: flex; flex-direction: column; }
+        .site-mobile-nav a { padding: 13px 4px; font-weight: 700; font-size: 15px; color: #16213E; border-bottom: 1px solid #E2E8F0; }
+        @media (min-width: 880px) { .site-nav--desktop { display: inline-flex; } .site-burger { display: none; } .site-mobile-drawer { display: none !important; } }
+        @media (max-width: 879px) {
+          :global(.nav-cta) { display: none !important; }
+        }
+      `}</style>
+    </header>
+  );
+}

--- a/projects/sewa-motor-malaysia/messages/en.json
+++ b/projects/sewa-motor-malaysia/messages/en.json
@@ -1,14 +1,33 @@
 {
   "nav": {
+    "home": "Home",
     "products": "Motorcycles",
+    "calculator": "Calculator",
     "locations": "Locations",
-    "whatsapp": "WhatsApp Us"
+    "blog": "Blog",
+    "whatsapp": "WhatsApp Us",
+    "whatsappCta": "WhatsApp"
+  },
+  "gallery": {
+    "alts": [
+      "Honda Vario 160 delivered in Petaling Jaya",
+      "Yamaha NMax 155 outside a KL condo",
+      "Honda PCX 160 with smart key",
+      "Honda Wave 125 for a food delivery rider",
+      "Yamaha Y15ZR on a city route",
+      "Modenas Kriss MR3 in fresh condition"
+    ]
+  },
+  "finalCta": {
+    "bgAlt": "Background photo of a motorcycle rider at Malaysian dusk"
   },
   "fomo": {
     "message": "Only {slots} bikes left for same-day delivery!",
     "bookNow": "Book Now"
   },
   "shared": {
+    "logoAlt": "Sewa Motor Malaysia logo",
+    "imageAlt": "Motorcycle rental — decorative image",
     "freeToAsk": "Free to ask · Reply within 1 hour",
     "safetyNote": "Safety-checked fleet · 30-day breakdown support",
     "stats": {
@@ -54,7 +73,8 @@
     "hero": {
       "headline": "Motor Rental Malaysia — Sewa Motor from RM30/day",
       "subheadline": "Rent reliable motorcycles delivered to your doorstep. Honda Vario, Yamaha NMax, PCX and more — daily, weekly, or monthly plans across Malaysia.",
-      "cta": "WhatsApp Us to Book Now"
+      "cta": "WhatsApp Us to Book Now",
+      "bgAlt": "Motorcycle rider on a Malaysian highway at dusk"
     },
     "stats": {
       "rentals": "6,000+ Rentals",
@@ -75,6 +95,8 @@
     "products": {
       "heading": "Motorcycle Rental Malaysia — Choose Your Ride",
       "cta": "Rent via WhatsApp",
+      "priceFromTemplate": "From RM {price}",
+      "imageAltTemplate": "Rent {model} in Malaysia — same-day delivery",
       "daily": "Daily",
       "weekly": "Weekly",
       "monthly": "Monthly",

--- a/projects/sewa-motor-malaysia/messages/ms.json
+++ b/projects/sewa-motor-malaysia/messages/ms.json
@@ -1,8 +1,29 @@
 {
   "nav": {
+    "home": "Laman Utama",
     "products": "Motosikal",
+    "calculator": "Kalkulator",
     "locations": "Lokasi",
-    "whatsapp": "WhatsApp Kami"
+    "blog": "Blog",
+    "whatsapp": "WhatsApp Kami",
+    "whatsappCta": "WhatsApp"
+  },
+  "shared": {
+    "logoAlt": "Logo Sewa Motor Malaysia",
+    "imageAlt": "Imej hiasan tema motosikal"
+  },
+  "gallery": {
+    "alts": [
+      "Honda Vario 160 dihantar di Petaling Jaya",
+      "Yamaha NMax 155 di hadapan kondominium KL",
+      "Honda PCX 160 dengan kunci pintar",
+      "Honda Wave 125 untuk penghantar makanan",
+      "Yamaha Y15ZR di laluan kota",
+      "Modenas Kriss MR3 dalam keadaan baharu"
+    ]
+  },
+  "finalCta": {
+    "bgAlt": "Latar belakang gambar penunggang motosikal di senja Malaysia"
   },
   "fomo": {
     "message": "Hanya tinggal {slots} motor untuk penghantaran hari yang sama!",
@@ -54,7 +75,8 @@
     "hero": {
       "headline": "Sewa Motor Malaysia — Dari RM30/hari",
       "subheadline": "Sewa motosikal yang dipercayai dihantar ke depan pintu anda. Honda Vario, Yamaha NMax, PCX dan lebih lagi — pelan harian, mingguan atau bulanan di seluruh Malaysia.",
-      "cta": "WhatsApp Kami Untuk Tempah Sekarang"
+      "cta": "WhatsApp Kami Untuk Tempah Sekarang",
+      "bgAlt": "Penunggang motosikal di jalan raya Malaysia ketika senja"
     },
     "stats": {
       "rentals": "6,000+ Sewaan",
@@ -75,6 +97,8 @@
     "products": {
       "heading": "Sewa Motosikal Malaysia — Pilih Tunggangan Anda",
       "cta": "Sewa Melalui WhatsApp",
+      "priceFromTemplate": "Dari RM {price}",
+      "imageAltTemplate": "Sewa motor {model} di Malaysia — penghantaran hari sama",
       "daily": "Harian",
       "weekly": "Mingguan",
       "monthly": "Bulanan",

--- a/projects/sewa-motor-malaysia/messages/zh.json
+++ b/projects/sewa-motor-malaysia/messages/zh.json
@@ -1,8 +1,29 @@
 {
   "nav": {
+    "home": "首页",
     "products": "电单车",
+    "calculator": "计算器",
     "locations": "服务地区",
-    "whatsapp": "立即WhatsApp"
+    "blog": "博客",
+    "whatsapp": "立即WhatsApp",
+    "whatsappCta": "WhatsApp"
+  },
+  "shared": {
+    "logoAlt": "Sewa Motor Malaysia 标志",
+    "imageAlt": "电单车租赁装饰图像"
+  },
+  "gallery": {
+    "alts": [
+      "Honda Vario 160 在八打灵再也送达",
+      "Yamaha NMax 155 停在吉隆坡公寓外",
+      "Honda PCX 160 配智能钥匙",
+      "Honda Wave 125 适合送餐骑士",
+      "Yamaha Y15ZR 在城市道路上",
+      "Modenas Kriss MR3 全新车况"
+    ]
+  },
+  "finalCta": {
+    "bgAlt": "马来西亚黄昏摩托车骑士的背景照片"
   },
   "fomo": {
     "message": "今日仅剩 {slots} 辆电单车可当天送达！",


### PR DESCRIPTION
Resolves the 24 Layout & Design failures by shipping the 5 canonical components (FomoBanner, SiteHeader, SiteFooter, MarketingMarquee, PageStyles), refactoring the homepage to have exactly one h1+h2 + role=img + the chrome, wiring blog list/detail to render the same chrome, and filling in the missing alt-text / nav / gallery / price-template / finalCta-bgAlt keys across en/ms/zh.

Also tightens `.gitignore` to exclude brand_assets/ + temporary screenshots/ and adds `.lsw-*` rules with `!important` in globals.css so the language switcher layout survives element resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)