### PR TITLE
fix(sewa-motor): clear remaining Layout & Design fails

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
@@ -130,7 +130,7 @@ function FomoBanner() {
         <span className="fomo-dot w-2 h-2 rounded-full bg-white shrink-0" />
         <span className="font-medium">{fomoT('message', { slots: slotsLeft })}</span>
         <span className="font-mono font-semibold px-2 py-0.5 rounded" style={{ background: 'rgba(0,0,0,0.25)' }}>{pad(timeLeft.hours)}:{pad(timeLeft.minutes)}:{pad(timeLeft.seconds)}</span>
-        <a href={waRedirect(locale)} className="font-semibold underline underline-offset-2 hover:no-underline shrink-0">{fomoT('bookNow')} &rarr;</a>
+        <a href={waRedirect(locale)} target="_blank" rel="noopener noreferrer" className="font-semibold underline underline-offset-2 hover:no-underline shrink-0">{fomoT('bookNow')} &rarr;</a>
       </div>
     </div>
   )
@@ -330,7 +330,7 @@ export default function HomePageClient() {
                             </div>
                           ))}
                         </div>
-                        <a href={waRedirect(locale, pk.waMsg)} className="inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg text-sm font-semibold text-white hover:opacity-90 w-full" style={{ background: 'var(--brand-primary)' }}>
+                        <a href={waRedirect(locale, pk.waMsg)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg text-sm font-semibold text-white hover:opacity-90 w-full" style={{ background: 'var(--brand-primary)' }}>
                           <WAIcon />{t('products.cta')}
                         </a>
                       </div>

--- a/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/LocationPageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/LocationPageClient.tsx
@@ -368,7 +368,7 @@ export default function LocationPageClient({
                             </div>
                           ))}
                         </div>
-                        <a href={waRedirect(locale, pk.waMsg + ' Location: ' + displayName, locationSlug)} className="inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg text-sm font-semibold text-white hover:opacity-90 w-full" style={{ background: 'var(--brand-primary)' }}>
+                        <a href={waRedirect(locale, pk.waMsg + ' Location: ' + displayName, locationSlug)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg text-sm font-semibold text-white hover:opacity-90 w-full" style={{ background: 'var(--brand-primary)' }}>
                           <WAIcon />{tProducts('cta')}
                         </a>
                       </div>

--- a/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/page.tsx
@@ -9,6 +9,10 @@ import { LocalBusinessSchema } from '@/components/schema/LocalBusinessSchema'
 import { BreadcrumbSchema } from '@/components/schema/BreadcrumbSchema'
 import { ProductSchema } from '@/components/schema/ProductSchema'
 import { FAQSchema } from '@/components/schema/FAQSchema'
+import FomoBanner from '@/components/FomoBanner'
+import SiteHeader from '@/components/SiteHeader'
+import SiteFooter from '@/components/SiteFooter'
+import PageStyles from '@/components/PageStyles'
 import LocationPageClient from './LocationPageClient'
 
 type Props = {
@@ -122,6 +126,8 @@ export default async function LocationPage({ params }: Props) {
 
   return (
     <>
+      <FomoBanner />
+      <SiteHeader />
       <LocalBusinessSchema
         locationName={displayName}
         locationSlug={loc.slug}
@@ -154,6 +160,8 @@ export default async function LocationPage({ params }: Props) {
           state: n.state,
         }))}
       />
+      <SiteFooter />
+      <PageStyles />
     </>
   )
 }

--- a/projects/sewa-motor-malaysia/components/PageStyles.tsx
+++ b/projects/sewa-motor-malaysia/components/PageStyles.tsx
@@ -7,6 +7,12 @@
 export default function PageStyles() {
   return (
     <style>{`
+      /* Normalisers ─────────────────────────────────────────────────── */
+      /* Without this, swapping an <h3> for an <h5> picks up the browser-default
+         huge heading sizes — every heading in these pages inherits weight from
+         its container so visual hierarchy is driven by classes, not by tag. */
+      h1, h2, h3, h4, h5, h6 { font-weight: inherit; }
+
       /* Hero ─────────────────────────────────────────────────────────── */
       .home-hero {
         position: relative;

--- a/projects/sewa-motor-malaysia/components/WhatsAppButton.tsx
+++ b/projects/sewa-motor-malaysia/components/WhatsAppButton.tsx
@@ -1,26 +1,36 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface WhatsAppButtonProps {
-  phones: string[];
+  /** Kept for API compatibility — phone selection now happens server-side
+   *  via /redirect-whatsapp-1 + webcore.getPhoneNumber, so this prop is
+   *  ignored. Components that still pass it stay working. */
+  phones?: string[];
   className?: string;
+  /** Optional tracking label (matches the standard uwc('click', { label })
+   *  pattern used elsewhere). */
+  label?: string;
 }
 
 export default function WhatsAppButton({
-  phones,
   className = "",
+  label = "wa-button",
 }: WhatsAppButtonProps) {
   const t = useTranslations("nav");
+  const locale = useLocale();
 
   function handleClick() {
-    const randomPhone = phones[Math.floor(Math.random() * phones.length)];
-    window.open(`https://wa.me/${randomPhone}`, "_blank", "noopener");
+    if (typeof window !== "undefined" && typeof window.uwc === "function") {
+      window.uwc("click", { label: `whatsapp-${label}` });
+    }
   }
 
   return (
-    <button
-      type="button"
+    <a
+      href={`/${locale}/redirect-whatsapp-1`}
+      target="_blank"
+      rel="noopener noreferrer"
       onClick={handleClick}
       className={`inline-flex items-center justify-center gap-2.5 px-6 py-3.5
         bg-[#25D366] hover:bg-[#1EBE5A] active:bg-[#1AA84E]
@@ -46,6 +56,6 @@ export default function WhatsAppButton({
         <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
       </svg>
       {t("whatsapp")}
-    </button>
+    </a>
   );
 }

--- a/projects/sewa-motor-malaysia/config/site.ts
+++ b/projects/sewa-motor-malaysia/config/site.ts
@@ -6,6 +6,7 @@ export const siteConfig = {
   domain,
   baseUrl: `https://${domain}`,
   siteUrl: `https://${domain}`,
+  productSlug: 'sewa-motor',
   fallbackPhone: '60174287801',
   defaultWhatsApp: 'https://wa.me/60174287801',
 }


### PR DESCRIPTION
Resolves the 3 remaining failures after the chrome refactor: WhatsApp CTA now routes through /redirect-whatsapp-1 (no direct wa.me), all CTA links open in new tab, PageStyles normalises h-tag font-weight, location page renders the chrome (productSlug set so the location-page-chrome checks can resolve).