### PR TITLE
fix(sewa-motor): drop sewamotor.my refs; canonicalize to .utopiaai.my

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
@@ -211,7 +211,7 @@ export default function HomePageClient() {
             </div>
             <div className="hidden sm:block">
               <div className="text-sm font-bold text-white leading-tight">Sewa Motor</div>
-              <div className="text-[11px] font-normal" style={{ color: 'rgba(255,255,255,0.45)' }}>sewamotor.my</div>
+              <div className="text-[11px] font-normal" style={{ color: 'rgba(255,255,255,0.45)' }}>Malaysia</div>
             </div>
           </a>
           <nav className="hidden md:flex items-center gap-6 text-sm font-medium" aria-label="Main navigation">

--- a/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/LocationPageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/sewa-motor/[location]/LocationPageClient.tsx
@@ -226,7 +226,7 @@ export default function LocationPageClient({
             </div>
             <div className="hidden sm:block">
               <div className="text-sm font-bold text-white leading-tight">Sewa Motor</div>
-              <div className="text-[11px] font-normal" style={{ color: 'rgba(255,255,255,0.45)' }}>sewamotor.my</div>
+              <div className="text-[11px] font-normal" style={{ color: 'rgba(255,255,255,0.45)' }}>Malaysia</div>
             </div>
           </Link>
           <nav className="hidden md:flex items-center gap-6 text-sm font-medium" aria-label="Main navigation">

--- a/projects/sewa-motor-malaysia/app/robots.ts
+++ b/projects/sewa-motor-malaysia/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { siteConfig } from "@/config/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -9,6 +10,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: "/api/",
       },
     ],
-    sitemap: "https://sewamotor.my/sitemap.xml",
+    sitemap: `${siteConfig.siteUrl}/sitemap.xml`,
   };
 }

--- a/projects/sewa-motor-malaysia/app/sitemap.ts
+++ b/projects/sewa-motor-malaysia/app/sitemap.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
 import { locations } from "@/config/locations";
+import { siteConfig } from "@/config/site";
 
-const BASE_URL = "https://sewamotor.my";
-const LOCALES = ["en", "zh"] as const;
+const BASE_URL = siteConfig.siteUrl;
+const LOCALES = ["en", "ms", "zh"] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const entries: MetadataRoute.Sitemap = [];

--- a/projects/sewa-motor-malaysia/components/schema/BreadcrumbSchema.tsx
+++ b/projects/sewa-motor-malaysia/components/schema/BreadcrumbSchema.tsx
@@ -1,3 +1,5 @@
+import { siteConfig } from "@/config/site";
+
 export function BreadcrumbSchema({
   locationName,
   locationSlug,
@@ -7,7 +9,7 @@ export function BreadcrumbSchema({
   locationSlug: string;
   locale: string;
 }) {
-  const baseUrl = "https://sewamotor.my";
+  const baseUrl = siteConfig.siteUrl;
 
   const schema = {
     "@context": "https://schema.org",

--- a/projects/sewa-motor-malaysia/components/schema/LocalBusinessSchema.tsx
+++ b/projects/sewa-motor-malaysia/components/schema/LocalBusinessSchema.tsx
@@ -14,12 +14,12 @@ export function LocalBusinessSchema({
   const schema = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
-    "@id": `https://sewamotor.my/${locale}/sewa-motor/${locationSlug}#localbusiness`,
-    name: `Sewa Motor Malaysia — ${locationName}`,
+    "@id": `${siteConfig.siteUrl}/${locale}/sewa-motor/${locationSlug}#localbusiness`,
+    name: `${siteConfig.brandName} — ${locationName}`,
     description: `Motorcycle rental service in ${locationName}, ${state}, Malaysia. Daily, weekly, and monthly motorbike rentals.`,
-    url: `https://sewamotor.my/${locale}/sewa-motor/${locationSlug}`,
+    url: `${siteConfig.siteUrl}/${locale}/sewa-motor/${locationSlug}`,
     telephone: `+${siteConfig.fallbackPhone}`,
-    image: "https://sewamotor.my/og-image.jpg",
+    image: `${siteConfig.siteUrl}/og-image.jpg`,
     address: {
       "@type": "PostalAddress",
       addressLocality: locationName,

--- a/projects/sewa-motor-malaysia/components/schema/OrganizationSchema.tsx
+++ b/projects/sewa-motor-malaysia/components/schema/OrganizationSchema.tsx
@@ -1,10 +1,12 @@
+import { siteConfig } from "@/config/site";
+
 export function OrganizationSchema() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "Organization",
-    name: "Sewa Motor Malaysia",
-    url: "https://sewamotor.my",
-    logo: "https://sewamotor.my/logo.png",
+    name: siteConfig.brandName,
+    url: siteConfig.siteUrl,
+    logo: `${siteConfig.siteUrl}/logo.png`,
     description:
       "Motorcycle rental service across 128 locations in Malaysia. Daily, weekly, and monthly rentals.",
     areaServed: {
@@ -13,8 +15,9 @@ export function OrganizationSchema() {
     },
     contactPoint: {
       "@type": "ContactPoint",
+      telephone: `+${siteConfig.fallbackPhone}`,
       contactType: "customer service",
-      availableLanguage: ["English", "Chinese"],
+      availableLanguage: ["English", "Malay", "Chinese"],
     },
     sameAs: [],
   };

--- a/projects/sewa-motor-malaysia/components/schema/ProductSchema.tsx
+++ b/projects/sewa-motor-malaysia/components/schema/ProductSchema.tsx
@@ -1,3 +1,5 @@
+import { siteConfig } from "@/config/site";
+
 interface ProductData {
   name: string;
   description: string;
@@ -42,7 +44,7 @@ export function ProductSchema({
           priceCurrency: "MYR",
           priceValidUntil: "2030-12-31",
           availability: "https://schema.org/InStock",
-          url: `https://sewamotor.my/${locale}/sewa-motor/${locationSlug}`,
+          url: `${siteConfig.siteUrl}/${locale}/sewa-motor/${locationSlug}`,
         },
         {
           "@type": "Offer",
@@ -51,7 +53,7 @@ export function ProductSchema({
           priceCurrency: "MYR",
           priceValidUntil: "2030-12-31",
           availability: "https://schema.org/InStock",
-          url: `https://sewamotor.my/${locale}/sewa-motor/${locationSlug}`,
+          url: `${siteConfig.siteUrl}/${locale}/sewa-motor/${locationSlug}`,
         },
         {
           "@type": "Offer",
@@ -60,7 +62,7 @@ export function ProductSchema({
           priceCurrency: "MYR",
           priceValidUntil: "2030-12-31",
           availability: "https://schema.org/InStock",
-          url: `https://sewamotor.my/${locale}/sewa-motor/${locationSlug}`,
+          url: `${siteConfig.siteUrl}/${locale}/sewa-motor/${locationSlug}`,
         },
       ],
     },

--- a/projects/sewa-motor-malaysia/config/site.ts
+++ b/projects/sewa-motor-malaysia/config/site.ts
@@ -1,4 +1,7 @@
-const domain = process.env.NEXT_PUBLIC_SITE_DOMAIN ?? 'sewamotor.my'
+// `sewamotor.my` is a separate Wix site that we do not own — siteConfig.domain
+// must reflect the alias actually serving this Next deploy so webcore lookups,
+// monitor_snapshots.domain, and schema URLs all point at the right place.
+const domain = process.env.NEXT_PUBLIC_SITE_DOMAIN ?? 'sewa-motor-malaysia.utopiaai.my'
 
 export const siteConfig = {
   name: 'Sewa Motor Malaysia',

--- a/projects/sewa-motor-malaysia/messages/en.json
+++ b/projects/sewa-motor-malaysia/messages/en.json
@@ -67,7 +67,7 @@
   },
   "home": {
     "meta": {
-      "title": "Sewa Motor Malaysia | #1 Motorcycle Rental from RM30/day | sewamotor.my",
+      "title": "Sewa Motor Malaysia | #1 Motorcycle Rental from RM30/day",
       "description": "Rent motorcycles across Malaysia from RM30/day. Honda Vario, Yamaha NMax, PCX & more. Same-day delivery. WhatsApp to book now. Sewa motor murah seluruh Malaysia."
     },
     "hero": {
@@ -209,7 +209,7 @@
   },
   "location": {
     "meta": {
-      "title": "Sewa Motor {city} | Motorcycle Rental from RM30/day | sewamotor.my",
+      "title": "Sewa Motor {city} | Motorcycle Rental from RM30/day",
       "description": "Rent motorcycles in {city} from RM30/day. Honda, Yamaha & Modenas — same-day delivery. WhatsApp to book your motorcycle rental in {city} today."
     },
     "breadcrumbs": {

--- a/projects/sewa-motor-malaysia/messages/ms.json
+++ b/projects/sewa-motor-malaysia/messages/ms.json
@@ -69,7 +69,7 @@
   },
   "home": {
     "meta": {
-      "title": "Sewa Motor Malaysia | Sewa Motosikal No.1 dari RM30/hari | sewamotor.my",
+      "title": "Sewa Motor Malaysia | Sewa Motosikal No.1 dari RM30/hari",
       "description": "Sewa motosikal di seluruh Malaysia dari RM30/hari. Honda Vario, Yamaha NMax, PCX dan lebih. Penghantaran hari sama. WhatsApp untuk tempah sekarang. Sewa motor murah seluruh Malaysia."
     },
     "hero": {
@@ -211,7 +211,7 @@
   },
   "location": {
     "meta": {
-      "title": "Sewa Motor {city} | Sewa Motosikal Dari RM30/hari | sewamotor.my",
+      "title": "Sewa Motor {city} | Sewa Motosikal Dari RM30/hari",
       "description": "Sewa motosikal di {city} dari RM30/hari. Honda, Yamaha & Modenas — penghantaran hari sama. WhatsApp untuk tempah sewa motosikal anda di {city} hari ini."
     },
     "breadcrumbs": {

--- a/projects/sewa-motor-malaysia/messages/zh.json
+++ b/projects/sewa-motor-malaysia/messages/zh.json
@@ -69,7 +69,7 @@
   },
   "home": {
     "meta": {
-      "title": "Sewa Motor Malaysia | 马来西亚电单车出租 RM30/天起 | sewamotor.my",
+      "title": "Sewa Motor Malaysia | 马来西亚电单车出租 RM30/天起",
       "description": "马来西亚电单车出租，每日RM30起。Honda Vario、Yamaha NMax、PCX等车型，当天送达。立即WhatsApp预订，便宜实惠的摩托车租赁服务。"
     },
     "hero": {
@@ -208,7 +208,7 @@
   },
   "location": {
     "meta": {
-      "title": "Sewa Motor {city} | 电单车出租 RM30/天起 | sewamotor.my",
+      "title": "Sewa Motor {city} | 电单车出租 RM30/天起",
       "description": "在{city}租电单车，每日RM30起。Honda、Yamaha、Modenas车型，当天送达。立即WhatsApp预订{city}电单车出租。"
     },
     "breadcrumbs": {

--- a/projects/sewa-motor-malaysia/middleware.ts
+++ b/projects/sewa-motor-malaysia/middleware.ts
@@ -1,8 +1,33 @@
 import createMiddleware from 'next-intl/middleware'
+import { NextRequest, NextResponse } from 'next/server'
 import { routing } from './i18n/routing'
 
-export default createMiddleware(routing)
+const CANONICAL_HOST = 'sewa-motor-malaysia.utopiaai.my'
+
+// Hosts we want to 301 to the canonical alias. Vercel auto-assigns the
+// `*.vercel.app` URL and there's no way to fully disable it, so we
+// redirect it instead. Add other non-canonical aliases here as they
+// surface (e.g. if a custom domain gets attached and we want it to be
+// canonical, swap CANONICAL_HOST and add the old one here).
+const NON_CANONICAL_HOSTS = new Set<string>([
+  'sewa-motor-malaysia.vercel.app',
+])
+
+const intl = createMiddleware(routing)
+
+export default function middleware(req: NextRequest) {
+  const host = req.headers.get('host') ?? ''
+
+  if (NON_CANONICAL_HOSTS.has(host)) {
+    const dest = new URL(req.nextUrl.toString())
+    dest.protocol = 'https:'
+    dest.host = CANONICAL_HOST
+    return NextResponse.redirect(dest, 308)
+  }
+
+  return intl(req)
+}
 
 export const config = {
-  matcher: ['/', '/(en|zh)/:path*'],
+  matcher: ['/', '/(en|ms|zh)/:path*'],
 }


### PR DESCRIPTION
## Summary
- `sewamotor.my` is a separate Wix site we do not own. Removed every reference in the sewa-motor-malaysia project so schema, sitemap, robots, footer brand caption, and locale meta titles all point at the canonical `sewa-motor-malaysia.utopiaai.my` via `siteConfig.siteUrl`
- `config/site.ts` default domain switched to the canonical alias; explanatory comment left in place so future me doesn't re-add the Wix host
- `middleware.ts` 308-redirects the Vercel-assigned `*.vercel.app` URL to the canonical alias so SERP/social shares stay consistent

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vercel deploy --prod --yes` succeeds and aliases to `sewa-motor-malaysia.utopiaai.my`
- [ ] Post-merge rescan: monitor checklist shows no `sewamotor.my` drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)