### PR TITLE
fix(sewa-motor): hero motor photo + mobile WA button + working FomoBanner

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/page.tsx
@@ -63,16 +63,30 @@ export default async function HomePage({
           aria-label={hero('bgAlt')}
         />
         <div className="home-hero-inner">
-          <h1>{hero('headline')}</h1>
-          <h2>{hero('subheadline')}</h2>
-          <Link
-            href={`/${locale}/redirect-whatsapp-1`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="home-hero-cta"
-          >
-            {hero('cta')}
-          </Link>
+          <div className="home-hero-text">
+            <h1>{hero('headline')}</h1>
+            <h2>{hero('subheadline')}</h2>
+            <Link
+              href={`/${locale}/redirect-whatsapp-1`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="home-hero-cta"
+            >
+              {hero('cta')}
+            </Link>
+          </div>
+          <div className="home-hero-media">
+            <img
+              src="https://static.wixstatic.com/media/d3104b_9219aed8e59e4a0d9ee86be2066ff532~mv2.png"
+              alt={hero('imageAlt')}
+              className="home-hero-photo"
+            />
+            <div className="home-hero-stamp" aria-hidden="true">
+              <span className="home-hero-stamp-from">From</span>
+              <span className="home-hero-stamp-price">RM30</span>
+              <span className="home-hero-stamp-per">/day</span>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/projects/sewa-motor-malaysia/components/FomoBanner.tsx
+++ b/projects/sewa-motor-malaysia/components/FomoBanner.tsx
@@ -4,67 +4,73 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
-function diffParts(target: Date) {
-  const ms = Math.max(0, target.getTime() - Date.now());
-  const days = Math.floor(ms / 86_400_000);
-  const hours = Math.floor((ms % 86_400_000) / 3_600_000);
-  const minutes = Math.floor((ms % 3_600_000) / 60_000);
-  const seconds = Math.floor((ms % 60_000) / 1000);
-  return { days, hours, minutes, seconds };
-}
-
 const pad = (n: number) => String(n).padStart(2, '0');
+
+function slotsForHour(hour: number) {
+  if (hour < 10) return 5;
+  if (hour < 14) return 3;
+  if (hour < 18) return 2;
+  return 1;
+}
 
 export default function FomoBanner() {
   const t = useTranslations('fomo');
   const locale = useLocale();
-  const [parts, setParts] = useState<{ days: number; hours: number; minutes: number; seconds: number } | null>(null);
+  const [parts, setParts] = useState<{ hours: number; minutes: number; seconds: number } | null>(null);
+  const [slots, setSlots] = useState(3);
 
   useEffect(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('sewamotor-promo-end') : null;
-    let end: Date;
-    if (stored && !Number.isNaN(Date.parse(stored)) && new Date(stored).getTime() > Date.now()) {
-      end = new Date(stored);
-    } else {
-      end = new Date(Date.now() + 7 * 86_400_000);
-      try { localStorage.setItem('sewamotor-promo-end', end.toISOString()); } catch { /* noop */ }
-    }
-    setParts(diffParts(end));
-    const id = setInterval(() => setParts(diffParts(end)), 1000);
+    const tick = () => {
+      const now = new Date();
+      const end = new Date(now);
+      end.setHours(23, 59, 59, 999);
+      const ms = Math.max(0, end.getTime() - now.getTime());
+      setParts({
+        hours: Math.floor(ms / 3_600_000),
+        minutes: Math.floor((ms % 3_600_000) / 60_000),
+        seconds: Math.floor((ms % 60_000) / 1000),
+      });
+      setSlots(slotsForHour(now.getHours()));
+    };
+    tick();
+    const id = setInterval(tick, 1000);
     return () => clearInterval(id);
   }, []);
 
   return (
     <div className="fomo-bar" role="region" aria-label="Promotional offer">
       <div className="fomo-inner">
-        <span className="fomo-tag">{t('eyebrow') || 'PROMO'}</span>
-        <span className="fomo-body">{t('body') || t('message') || ''}</span>
+        <span className="fomo-dot" aria-hidden="true" />
+        <span className="fomo-body">{t('message', { slots })}</span>
         <span aria-live="polite" className="fomo-clock">
-          {parts ? (
-            <>
-              <span>{pad(parts.days)}</span>
-              <span>:</span>
-              <span>{pad(parts.hours)}</span>
-              <span>:</span>
-              <span>{pad(parts.minutes)}</span>
-              <span>:</span>
-              <span>{pad(parts.seconds)}</span>
-            </>
-          ) : (
-            <span style={{ visibility: 'hidden' }}>00 : 00 : 00 : 00</span>
+          {parts ? `${pad(parts.hours)}:${pad(parts.minutes)}:${pad(parts.seconds)}` : (
+            <span style={{ visibility: 'hidden' }}>00:00:00</span>
           )}
         </span>
         <Link href={`/${locale}/redirect-whatsapp-1`} className="fomo-link" target="_blank" rel="noopener noreferrer">
-          {t('bookNow') || t('ctaLabel') || 'Book Now'} →
+          {t('bookNow')} →
         </Link>
       </div>
       <style jsx>{`
         .fomo-bar { background: #B91C1C; color: #fff; font-size: 13px; padding: 8px 16px; }
         .fomo-inner { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: center; gap: 12px; flex-wrap: wrap; }
-        .fomo-tag { font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.9; }
+        .fomo-dot {
+          width: 8px; height: 8px; border-radius: 999px; background: #fff;
+          flex-shrink: 0;
+          animation: fomo-pulse 1.4s ease-in-out infinite;
+        }
+        @keyframes fomo-pulse {
+          0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(255,255,255,0.6); }
+          50% { opacity: 0.6; box-shadow: 0 0 0 6px rgba(255,255,255,0); }
+        }
         .fomo-body { font-weight: 500; }
-        .fomo-clock { font-variant-numeric: tabular-nums; font-weight: 600; }
+        .fomo-clock {
+          font-variant-numeric: tabular-nums; font-weight: 700;
+          background: rgba(0,0,0,0.28); padding: 2px 8px; border-radius: 6px;
+          letter-spacing: 0.02em;
+        }
         .fomo-link { font-weight: 700; text-decoration: underline; }
+        .fomo-link:hover { text-decoration: none; }
       `}</style>
     </div>
   );

--- a/projects/sewa-motor-malaysia/components/PageStyles.tsx
+++ b/projects/sewa-motor-malaysia/components/PageStyles.tsx
@@ -16,12 +16,16 @@ export default function PageStyles() {
       /* Hero ─────────────────────────────────────────────────────────── */
       .home-hero {
         position: relative;
-        padding: 96px 24px 64px;
+        padding: 80px 24px 64px;
         background: linear-gradient(135deg, #16213E 0%, #1A2744 60%, #0F172A 100%);
         color: #fff;
         overflow: hidden;
       }
-      .home-hero-inner { max-width: 1100px; margin: 0 auto; position: relative; z-index: 1; text-align: center; }
+      .home-hero-inner {
+        max-width: 1100px; margin: 0 auto; position: relative; z-index: 1;
+        display: grid; grid-template-columns: 1fr; gap: 32px; align-items: center;
+        text-align: center;
+      }
       .home-hero-bg {
         position: absolute; inset: 0;
         background-image: linear-gradient(135deg, rgba(22,33,62,0.85), rgba(15,23,42,0.95)), url('/og-image.jpg');
@@ -51,6 +55,34 @@ export default function PageStyles() {
         padding: 14px 30px;
         border-radius: 999px;
         text-decoration: none;
+      }
+      .home-hero-media {
+        position: relative;
+        display: flex; align-items: center; justify-content: center;
+      }
+      .home-hero-photo {
+        display: block;
+        width: 100%; max-width: 420px; height: auto;
+        filter: drop-shadow(0 12px 32px rgba(0,0,0,0.35));
+      }
+      .home-hero-stamp {
+        position: absolute; top: 12px; right: 4px;
+        background: #FF6B35;
+        padding: 10px 16px;
+        transform: skewX(-6deg);
+        box-shadow: 0 6px 20px rgba(255,107,53,0.4);
+        display: flex; flex-direction: column; align-items: center;
+        line-height: 1;
+      }
+      .home-hero-stamp > span { transform: skewX(6deg); color: #fff; }
+      .home-hero-stamp-from { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+      .home-hero-stamp-price { font-size: 24px; font-weight: 800; margin: 2px 0; }
+      .home-hero-stamp-per { font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; }
+      @media (min-width: 880px) {
+        .home-hero { padding: 96px 24px 80px; }
+        .home-hero-inner { grid-template-columns: 1.05fr 0.95fr; gap: 48px; text-align: left; }
+        .home-hero h2 { margin-left: 0; margin-right: 0; }
+        .home-hero-media { justify-content: flex-end; }
       }
 
       /* USP panel ────────────────────────────────────────────────────── */

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -46,6 +46,18 @@ export default function SiteHeader() {
           >
             {t('whatsappCta')}
           </Link>
+          <Link
+            href={`/${locale}/redirect-whatsapp-1`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-cta-mobile"
+            aria-label={t('whatsappCta')}
+          >
+            <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="currentColor">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/>
+              <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z"/>
+            </svg>
+          </Link>
         </div>
       </div>
 
@@ -83,13 +95,25 @@ export default function SiteHeader() {
           padding: 8px 14px; border-radius: 999px; font-weight: 700; font-size: 13px;
           white-space: nowrap;
         }
+        .nav-cta-mobile {
+          display: inline-flex; align-items: center; justify-content: center;
+          width: 38px; height: 38px; border-radius: 999px;
+          background: var(--wa-green, #25D366); color: #fff;
+          box-shadow: 0 2px 8px rgba(37,211,102,0.4);
+        }
+        .nav-cta-mobile:hover { background: #1EBE57; }
         .site-burger { display: inline-flex; flex-direction: column; justify-content: center; gap: 4px; width: 38px; height: 38px; padding: 0 8px; background: transparent; border: 1px solid #CBD5E1; border-radius: 10px; cursor: pointer; }
         .site-burger span { display: block; height: 2px; width: 100%; background: #16213E; border-radius: 2px; }
         .site-mobile-drawer { display: none; background: #fff; border-top: 1px solid #E2E8F0; padding: 14px 20px 18px; }
         .site-mobile-drawer.is-open { display: block; }
         .site-mobile-nav { display: flex; flex-direction: column; }
         .site-mobile-nav a { padding: 13px 4px; font-weight: 700; font-size: 15px; color: #16213E; border-bottom: 1px solid #E2E8F0; }
-        @media (min-width: 880px) { .site-nav--desktop { display: inline-flex; } .site-burger { display: none; } .site-mobile-drawer { display: none !important; } }
+        @media (min-width: 880px) {
+          .site-nav--desktop { display: inline-flex; }
+          .site-burger { display: none; }
+          .site-mobile-drawer { display: none !important; }
+          .nav-cta-mobile { display: none; }
+        }
         @media (max-width: 879px) {
           :global(.nav-cta) { display: none !important; }
         }

--- a/projects/sewa-motor-malaysia/messages/en.json
+++ b/projects/sewa-motor-malaysia/messages/en.json
@@ -74,7 +74,8 @@
       "headline": "Motor Rental Malaysia — Sewa Motor from RM30/day",
       "subheadline": "Rent reliable motorcycles delivered to your doorstep. Honda Vario, Yamaha NMax, PCX and more — daily, weekly, or monthly plans across Malaysia.",
       "cta": "WhatsApp Us to Book Now",
-      "bgAlt": "Motorcycle rider on a Malaysian highway at dusk"
+      "bgAlt": "Motorcycle rider on a Malaysian highway at dusk",
+      "imageAlt": "Honda Vario motorcycle available for rental in Malaysia"
     },
     "stats": {
       "rentals": "6,000+ Rentals",

--- a/projects/sewa-motor-malaysia/messages/ms.json
+++ b/projects/sewa-motor-malaysia/messages/ms.json
@@ -76,7 +76,8 @@
       "headline": "Sewa Motor Malaysia — Dari RM30/hari",
       "subheadline": "Sewa motosikal yang dipercayai dihantar ke depan pintu anda. Honda Vario, Yamaha NMax, PCX dan lebih lagi — pelan harian, mingguan atau bulanan di seluruh Malaysia.",
       "cta": "WhatsApp Kami Untuk Tempah Sekarang",
-      "bgAlt": "Penunggang motosikal di jalan raya Malaysia ketika senja"
+      "bgAlt": "Penunggang motosikal di jalan raya Malaysia ketika senja",
+      "imageAlt": "Motosikal Honda Vario tersedia untuk sewa di Malaysia"
     },
     "stats": {
       "rentals": "6,000+ Sewaan",

--- a/projects/sewa-motor-malaysia/messages/zh.json
+++ b/projects/sewa-motor-malaysia/messages/zh.json
@@ -75,7 +75,9 @@
     "hero": {
       "headline": "马来西亚电单车出租 — 每日RM30起",
       "subheadline": "租赁可靠的电单车，直送到您家门口。Honda Vario、Yamaha NMax、PCX等多款车型 — 日租、周租或月租，覆盖马来西亚全国。",
-      "cta": "立即WhatsApp预订"
+      "cta": "立即WhatsApp预订",
+      "bgAlt": "马来西亚高速公路上的黄昏电单车骑士",
+      "imageAlt": "Honda Vario 电单车马来西亚出租"
     },
     "stats": {
       "rentals": "6,000+ 次出租",


### PR DESCRIPTION
## Summary

### Hero motor photo
The Layout & Design refactor removed the inline client-side hero, which also dropped the motorcycle product photo. Re-add it as part of the **server** hero: 2-col grid (text + media) on desktop, single-column stack on mobile. Adds a skewed "From RM30/day" price stamp over the photo. New translation key \`home.hero.imageAlt\` across en/ms/zh.

### Mobile WhatsApp button
Below 880px the header's \`.nav-cta\` pill is hidden by design — the \`header-mobile-wa-hidden\` checklist rule deliberately enforces this to avoid overlap with the language switcher. Added a separate \`.nav-cta-mobile\` circular icon button visible only <880px so the WA action is still reachable on phone. Desktop layout unchanged.

### FomoBanner
Old banner read \`t('eyebrow')\` and \`t('body')\` — keys that do not exist in any locale file. next-intl falls back to the key path itself, so the banner literally rendered "fomo.eyebrow" / "fomo.body" and the \`{slots}\` placeholder was never interpolated. Rewrote to:
- Use the keys that actually exist (\`message\` with \`slots\` interpolation, \`bookNow\`)
- Pulse-dot eyebrow instead of a missing "PROMO" string
- Proper end-of-day HH:MM:SS countdown (vs. the localStorage-anchored 7-day clock)
- Slot count driven by hour-of-day, matching the legacy client behavior

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vercel deploy --prod --yes\` aliased to \`sewa-motor-malaysia.utopiaai.my\`
- [ ] Visual: hero shows motorcycle + price stamp on desktop, stacks on mobile
- [ ] Mobile (<880px): green WA circle visible in header next to language switcher
- [ ] FomoBanner: shows red bar with pulsing dot, "Only 3 bikes left…" copy, ticking HH:MM:SS clock, Book Now link

🤖 Generated with [Claude Code](https://claude.com/claude-code)