### PR TITLE
fix(sewa-motor): footer gap, marquee placement, header logo + WA + LSW

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/page.tsx
@@ -105,10 +105,9 @@ export default async function HomePage({
         </div>
       </div>
 
-      <MarketingMarquee variant="light" />
-
       <HomePageClient />
 
+      <MarketingMarquee variant="dark" />
       <SiteFooter />
       <PageStyles />
     </>

--- a/projects/sewa-motor-malaysia/app/globals.css
+++ b/projects/sewa-motor-malaysia/app/globals.css
@@ -119,36 +119,105 @@ h1, h2, h3, h4, h5, h6 {
   background-clip: text;
 }
 
-/* ── Language switcher (high-specificity overrides so element resets don't
- *    clobber the dropdown's flex layout) ─────────────────────────────────── */
+/* ── Language switcher — standalone bordered pills + circle flags ─────────
+ *    Layout rules carry !important so element resets / Tailwind don't win. */
+.lsw { position: relative; display: inline-flex; }
 .lsw-toggle {
   display: inline-flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
   align-items: center !important;
   gap: 6px !important;
-  flex-direction: row !important;
 }
 .lsw-item {
   display: inline-flex !important;
-  align-items: center !important;
-  gap: 6px !important;
   flex-direction: row !important;
-  padding: 6px 12px;
+  flex-wrap: nowrap !important;
+  align-items: center !important;
+  gap: 8px !important;
+  height: 36px;
+  padding: 0 14px 0 8px;
   border-radius: 999px;
+  background: #FFFFFF;
+  border: 1.5px solid #CBD5E1;
+  color: #16213E;
+  font-weight: 700;
   font-size: 13px;
-  font-weight: 600;
-  color: var(--brand-text);
-  border: 1px solid transparent;
-  background: transparent;
+  letter-spacing: 0.02em;
+  line-height: 1;
   text-decoration: none;
+  white-space: nowrap;
+  transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
 }
-.lsw-item:hover { background: var(--brand-primary-xs); }
+.lsw-item:hover { border-color: rgba(15,15,15,0.35); background: #F1F5F9; }
 .lsw-item.is-active {
-  background: var(--brand-dark);
-  color: #fff !important;
+  background: #16213E;
+  border-color: #16213E;
+  color: #FFFFFF !important;
+  box-shadow: 0 4px 12px rgba(15,15,15,0.18);
 }
-.lsw-label { display: inline-block; line-height: 1; white-space: nowrap; }
-.lsw-flag { display: inline-block; line-height: 1; }
-.lsw-caret { opacity: 0.6; }
+.lsw-flag {
+  display: inline-block !important;
+  flex-shrink: 0;
+  vertical-align: middle;
+  width: 20px;
+  height: 20px;
+}
+.lsw-label { display: inline-block; flex-shrink: 0; line-height: 1; white-space: nowrap; }
+
+/* Dropdown trigger (mobile only) */
+.lsw-trigger {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 12px 0 8px;
+  background: #FFFFFF;
+  border: 1.5px solid #CBD5E1;
+  border-radius: 999px;
+  color: #16213E;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  cursor: pointer;
+}
+.lsw-trigger-label { display: inline-block; line-height: 1; }
+.lsw-caret { opacity: 0.6; transition: transform 0.18s ease; }
+.lsw-trigger[aria-expanded="true"] .lsw-caret { transform: rotate(180deg); }
+.lsw-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 140px;
+  background: #FFFFFF;
+  border: 1px solid #E2E8F0;
+  border-radius: 14px;
+  box-shadow: 0 18px 40px -12px rgba(15,15,15,0.25);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  z-index: 60;
+}
+.lsw-menu-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: #16213E;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.lsw-menu-item:hover { background: #F1F5F9; }
+.lsw-menu-item.is-active { background: #16213E; color: #fff; }
+
+@media (max-width: 879px) {
+  .lsw-toggle { display: none !important; }
+  .lsw-trigger { display: inline-flex; }
+}
 
 /* ── USP panel (single container with 3 cells) ─────────────────────────── */
 .usp-panel-fallback { /* keep .usp-panel from PageStyles authoritative */ }

--- a/projects/sewa-motor-malaysia/components/LanguageSwitcher.tsx
+++ b/projects/sewa-motor-malaysia/components/LanguageSwitcher.tsx
@@ -1,97 +1,157 @@
-"use client";
+'use client';
 
-import { useLocale } from "next-intl";
-import { routing } from "@/i18n/routing";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect, useId, useRef, useState } from 'react';
+import { routing } from '@/i18n/routing';
 
-const languageLabels: Record<string, string> = {
-  en: "EN",
-  zh: "中文",
-};
+const LABELS: Record<string, string> = { ms: 'MS', en: 'EN', zh: '中' };
+
+function starPoints(cx: number, cy: number, outer: number, rot = -Math.PI / 2): string {
+  const inner = outer * 0.382;
+  const pts: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const angle = rot + (Math.PI / 5) * i;
+    const r = i % 2 === 0 ? outer : inner;
+    pts.push(`${(cx + r * Math.cos(angle)).toFixed(2)},${(cy + r * Math.sin(angle)).toFixed(2)}`);
+  }
+  return pts.join(' ');
+}
+
+function CircleFlag({ locale }: { locale: string }) {
+  const uid = useId().replace(/:/g, '');
+  const id = `clip-${locale}-${uid}`;
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" className="lsw-flag">
+      <defs><clipPath id={id}><circle cx="12" cy="12" r="11.5" /></clipPath></defs>
+      <g clipPath={`url(#${id})`}>
+        {locale === 'ms' && (
+          <>
+            <rect width="24" height="24" fill="#fff" />
+            {[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map((y, i) => (
+              <rect key={y} y={y - 4} width="24" height="2" fill={i % 2 === 0 ? '#CC0001' : '#FFFFFF'} />
+            ))}
+            <rect width="13" height="13" fill="#010066" />
+            <circle cx="5.5" cy="6.5" r="3" fill="#FFCC00" />
+            <circle cx="6.6" cy="6" r="2.6" fill="#010066" />
+            <polygon points={starPoints(9.5, 6.5, 1.8)} fill="#FFCC00" />
+          </>
+        )}
+        {locale === 'en' && (
+          <>
+            <rect width="24" height="24" fill="#012169" />
+            <path d="M0,0 L24,24 M24,0 L0,24" stroke="#FFFFFF" strokeWidth="5" />
+            <path d="M0,0 L24,24" stroke="#C8102E" strokeWidth="2" />
+            <path d="M24,0 L0,24" stroke="#C8102E" strokeWidth="2" />
+            <path d="M12,0 V24 M0,12 H24" stroke="#FFFFFF" strokeWidth="7" />
+            <path d="M12,0 V24 M0,12 H24" stroke="#C8102E" strokeWidth="4" />
+          </>
+        )}
+        {locale === 'zh' && (
+          <>
+            <rect width="24" height="24" fill="#EE1C25" />
+            <polygon points={starPoints(7, 7, 3.2)} fill="#FFFF00" />
+            {[{ x: 12, y: 3 }, { x: 14, y: 5.5 }, { x: 14, y: 9 }, { x: 12, y: 11 }].map((s, i) => {
+              const angle = Math.atan2(7 - s.y, 7 - s.x);
+              return <polygon key={i} points={starPoints(s.x, s.y, 1.2, angle)} fill="#FFFF00" />;
+            })}
+          </>
+        )}
+      </g>
+      <circle cx="12" cy="12" r="11.5" fill="none" stroke="rgba(15,15,15,0.18)" strokeWidth="1" />
+    </svg>
+  );
+}
 
 export default function LanguageSwitcher() {
-  const locale = useLocale();
-  const pathname = usePathname();
+  const currentLocale = useLocale();
+  const pathname = usePathname() || '/';
+  const search = useSearchParams();
+  const qs = search?.toString();
+  const suffix = qs ? `?${qs}` : '';
+  const rest = (() => {
+    for (const l of routing.locales) {
+      if (pathname === `/${l}`) return '';
+      if (pathname.startsWith(`/${l}/`)) return pathname.slice(`/${l}`.length);
+    }
+    return pathname === '/' ? '' : pathname;
+  })();
 
-  // Remove current locale prefix from pathname to get the base path
-  const pathnameWithoutLocale = pathname.replace(/^\/(en|zh)/, "") || "/";
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
 
   return (
-    <div className="relative group">
-      {/* Trigger: globe icon + current locale code */}
+    <div className="lsw" ref={rootRef}>
+      <div className="lsw-toggle" role="group" aria-label="Change language">
+        {routing.locales.map((l) => {
+          const active = l === currentLocale;
+          return (
+            <Link
+              key={l}
+              href={`/${l}${rest}${suffix}`}
+              hrefLang={l}
+              lang={l}
+              className={`lsw-item ${active ? 'is-active' : ''}`}
+              aria-current={active ? 'true' : undefined}
+            >
+              <CircleFlag locale={l} />
+              <span className="lsw-label">{LABELS[l] ?? l.toUpperCase()}</span>
+            </Link>
+          );
+        })}
+      </div>
+
       <button
         type="button"
-        className="flex items-center gap-1.5 px-3 py-2 text-white/90 hover:text-white
-                   transition-colors duration-200 rounded-lg
-                   hover:bg-white/10 focus:bg-white/10 focus:outline-none
-                   focus:ring-2 focus:ring-red-500/50 active:bg-white/15
-                   text-sm font-medium tracking-wide cursor-pointer"
-        aria-label="Switch language"
+        className="lsw-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Change language"
+        onClick={() => setOpen((v) => !v)}
       >
-        {/* Globe icon */}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="12" cy="12" r="10" />
-          <path d="M2 12h20" />
-          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-        </svg>
-        <span>{locale.toUpperCase()}</span>
-        {/* Chevron */}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-          className="transition-transform duration-200 group-hover:rotate-180"
-        >
-          <polyline points="6 9 12 15 18 9" />
+        <CircleFlag locale={currentLocale} />
+        <span className="lsw-trigger-label">{LABELS[currentLocale] ?? currentLocale.toUpperCase()}</span>
+        <svg className="lsw-caret" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M1 3l4 4 4-4" stroke="currentColor" strokeWidth="1.6" fill="none" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
 
-      {/* Dropdown menu — CSS-only via group-hover */}
-      <ul
-        className="absolute right-0 top-full mt-1 min-w-[140px] py-1
-                    bg-gray-900 border border-white/10 rounded-lg
-                    shadow-[0_4px_20px_rgba(0,0,0,0.4),0_0_0_1px_rgba(255,255,255,0.05)]
-                    opacity-0 invisible translate-y-1
-                    group-hover:opacity-100 group-hover:visible group-hover:translate-y-0
-                    transition-all duration-200 z-50"
-      >
-        {routing.locales.map((loc) => (
-          <li key={loc}>
-            <Link
-              href={`/${loc}${pathnameWithoutLocale}`}
-              hrefLang={loc}
-              className={`block px-4 py-2.5 text-sm transition-colors duration-150
-                ${
-                  loc === locale
-                    ? "text-red-400 bg-red-500/10 font-semibold"
-                    : "text-white/80 hover:text-white hover:bg-white/10"
-                }
-                focus:outline-none focus:bg-white/10 active:bg-white/15`}
-            >
-              {languageLabels[loc]}
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {open && (
+        <div className="lsw-menu" role="menu">
+          {routing.locales.map((l) => {
+            const active = l === currentLocale;
+            return (
+              <Link
+                key={l}
+                href={`/${l}${rest}${suffix}`}
+                hrefLang={l}
+                lang={l}
+                role="menuitem"
+                className={`lsw-menu-item ${active ? 'is-active' : ''}`}
+                onClick={() => setOpen(false)}
+              >
+                <CircleFlag locale={l} />
+                <span>{LABELS[l] ?? l.toUpperCase()}</span>
+              </Link>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/projects/sewa-motor-malaysia/components/SiteFooter.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteFooter.tsx
@@ -33,7 +33,7 @@ export default function SiteFooter() {
         <p>{t('copyright', { year })}</p>
       </div>
       <style jsx>{`
-        .site-footer { background: #0F172A; color: #E2E8F0; margin-top: 64px; }
+        .site-footer { background: #0F172A; color: #E2E8F0; }
         .site-footer-inner { max-width: 1200px; margin: 0 auto; padding: 48px 20px 24px; display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 32px; }
         .footer-col { display: flex; flex-direction: column; gap: 10px; }
         .footer-brand { font-weight: 800; font-size: 18px; color: #fff; margin: 0; }

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -14,7 +14,17 @@ export default function SiteHeader() {
   return (
     <header className="site-header">
       <div className="site-header-inner">
-        <Link href={`/${locale}`} className="site-brand">Sewa Motor Malaysia</Link>
+        <Link href={`/${locale}`} className="site-brand" aria-label="Sewa Motor Malaysia homepage">
+          <span className="site-brand-icon" aria-hidden="true">
+            <svg viewBox="0 0 32 32" width="22" height="22" fill="none">
+              <circle cx="7" cy="23" r="4" stroke="currentColor" strokeWidth="2" />
+              <circle cx="25" cy="23" r="4" stroke="currentColor" strokeWidth="2" />
+              <path d="M11 23h10M7 23l4-10h6l4 3h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M17 13l2-4h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </span>
+          <span className="site-brand-text">Sewa Motor Malaysia</span>
+        </Link>
         <nav className="site-nav site-nav--desktop" aria-label="Primary">
           <Link href={`/${locale}`}>{t('home')}</Link>
           <Link href={`/${locale}#products`}>{t('products')}</Link>
@@ -44,7 +54,11 @@ export default function SiteHeader() {
             rel="noopener noreferrer"
             className="nav-cta"
           >
-            {t('whatsappCta')}
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="currentColor">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/>
+              <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z"/>
+            </svg>
+            <span>{t('whatsappCta')}</span>
           </Link>
           <Link
             href={`/${locale}/redirect-whatsapp-1`}
@@ -84,17 +98,31 @@ export default function SiteHeader() {
           display: flex; align-items: center; justify-content: space-between;
           gap: 12px; padding: 12px 20px; min-height: 60px;
         }
-        .site-brand { font-weight: 800; font-size: 15px; color: var(--brand-dark, #16213E); white-space: nowrap; }
+        .site-brand {
+          display: inline-flex; align-items: center; gap: 10px;
+          font-weight: 800; font-size: 15px; color: var(--brand-dark, #16213E);
+          white-space: nowrap; text-decoration: none;
+        }
+        .site-brand-icon {
+          display: inline-flex; align-items: center; justify-content: center;
+          width: 36px; height: 36px; border-radius: 10px;
+          background: var(--brand-primary, #FF6B35);
+          color: #fff;
+          box-shadow: 0 4px 12px rgba(255,107,53,0.35);
+        }
+        .site-brand-text { line-height: 1; }
         .site-nav { display: inline-flex; gap: 24px; }
         .site-nav a { color: var(--brand-text, #1B2432); font-weight: 600; font-size: 14px; white-space: nowrap; }
         .site-nav a:hover { color: var(--brand-primary, #FF6B35); }
         .site-nav--desktop { display: none; }
         .site-actions { display: inline-flex; align-items: center; gap: 10px; }
         .nav-cta {
+          display: inline-flex; align-items: center; gap: 7px;
           background: var(--wa-green, #25D366); color: #fff;
           padding: 8px 14px; border-radius: 999px; font-weight: 700; font-size: 13px;
           white-space: nowrap;
         }
+        .nav-cta:hover { background: #1EBE57; }
         .nav-cta-mobile {
           display: inline-flex; align-items: center; justify-content: center;
           width: 38px; height: 38px; border-radius: 999px;
@@ -116,6 +144,9 @@ export default function SiteHeader() {
         }
         @media (max-width: 879px) {
           :global(.nav-cta) { display: none !important; }
+        }
+        @media (max-width: 640px) {
+          .site-brand-text { display: none; }
         }
       `}</style>
     </header>


### PR DESCRIPTION
## Summary
Visual cleanup pass on \`sewa-motor-malaysia\`:

- **Footer gap** — \`.site-footer\` had \`margin-top: 64px\`, painting a light-cream stripe between the dark final-CTA section and the dark footer. Removed.
- **Marquee location** — moved \`<MarketingMarquee>\` from mid-page (after USP) to just above \`<SiteFooter>\`. Flipped to \`variant="dark"\` so it reads as a closing announcement strip.
- **Header logo icon** — restored the orange brand mark (rounded square + motorcycle SVG glyph). Label hides <640px so the icon alone carries the brand on small phones.
- **Header WhatsApp button** — desktop pill now includes the WhatsApp glyph next to the label + hover state. Mobile circle button unchanged.
- **LanguageSwitcher** — was using \`text-white/90\` which rendered invisible on the new white header. Replaced with the canonical bordered-pill + circular SVG flag pattern. Added matching \`.lsw-*\` rules to globals.css.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vercel deploy --prod --yes\` aliased to \`sewa-motor-malaysia.utopiaai.my\`
- [ ] Visual: footer butts against final CTA with no cream gap; marquee strip sits just above footer; header shows orange motorcycle icon + brand label, language pills (MS / EN / 中), green WhatsApp pill with icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)