### PR TITLE
fix(sewa-motor): unbreak header WhatsApp pill + put Stats above USP

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/HomePageClient.tsx
@@ -200,25 +200,6 @@ export default function HomePageClient() {
   return (
     <div style={{ background: 'var(--brand-surface)' }}>
       <main>
-        {/* ── STATS ── */}
-        <section style={{ background: 'var(--brand-dark)' }}>
-          <div className="max-w-6xl mx-auto px-6 py-10 grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
-            {[
-              { value: s('stats.value1'), label: s('stats.label1') },
-              { value: s('stats.value2'), label: s('stats.label2') },
-              { value: s('stats.value3'), label: s('stats.label3') },
-              { value: s('stats.value4'), label: s('stats.label4') },
-            ].map((stat, i) => (
-              <FadeSection key={i} delay={i * 80}>
-                <div>
-                  <div className="text-2xl md:text-3xl font-extrabold mb-2" style={{ color: 'var(--brand-primary)', letterSpacing: '-0.03em' }}>{stat.value}</div>
-                  <div className="text-xs font-normal" style={{ color: 'rgba(255,255,255,0.55)', lineHeight: '1.5' }}>{stat.label}</div>
-                </div>
-              </FadeSection>
-            ))}
-          </div>
-        </section>
-
         {/* ── PRODUCTS ── */}
         <section id="products" className="py-16 px-6" style={{ background: 'var(--brand-surface)' }} aria-labelledby="products-heading">
           <div className="max-w-6xl mx-auto">

--- a/projects/sewa-motor-malaysia/app/[locale]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/page.tsx
@@ -49,6 +49,7 @@ export default async function HomePage({
   const { locale } = await params
   const hero = await getTranslations({ locale, namespace: 'home.hero' })
   const shared = await getTranslations({ locale, namespace: 'shared' })
+  const stats = [1, 2, 3, 4] as const
 
   return (
     <>
@@ -87,6 +88,17 @@ export default async function HomePage({
               <span className="home-hero-stamp-per">/day</span>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="home-stats" aria-label="Service highlights">
+        <div className="home-stats-grid">
+          {stats.map((n) => (
+            <div className="home-stat" key={n}>
+              <div className="home-stat-value">{shared(`stats.value${n}` as 'stats.value1')}</div>
+              <div className="home-stat-label">{shared(`stats.label${n}` as 'stats.label1')}</div>
+            </div>
+          ))}
         </div>
       </section>
 

--- a/projects/sewa-motor-malaysia/app/globals.css
+++ b/projects/sewa-motor-malaysia/app/globals.css
@@ -222,7 +222,39 @@ h1, h2, h3, h4, h5, h6 {
 /* ── USP panel (single container with 3 cells) ─────────────────────────── */
 .usp-panel-fallback { /* keep .usp-panel from PageStyles authoritative */ }
 
-/* ── Nav CTA mobile-hide fallback (header also enforces this) ──────────── */
+/* ── Header WhatsApp CTAs — kept in globals because styled-jsx in
+ *    SiteHeader doesn't scope rules through next/link's <Link>. */
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: #25D366;
+  color: #fff !important;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 13px;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.nav-cta:hover { background: #1EBE57; }
+.nav-cta-mobile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  background: #25D366;
+  color: #fff !important;
+  box-shadow: 0 2px 8px rgba(37,211,102,0.4);
+  text-decoration: none;
+}
+.nav-cta-mobile:hover { background: #1EBE57; }
+
+@media (min-width: 880px) {
+  .nav-cta-mobile { display: none !important; }
+}
 @media (max-width: 879px) {
   .nav-cta { display: none !important; }
 }

--- a/projects/sewa-motor-malaysia/components/PageStyles.tsx
+++ b/projects/sewa-motor-malaysia/components/PageStyles.tsx
@@ -85,6 +85,29 @@ export default function PageStyles() {
         .home-hero-media { justify-content: flex-end; }
       }
 
+      /* Stats strip (sits between hero and USP) ───────────────────────── */
+      .home-stats {
+        background: #16213E;
+        padding: 56px 24px 72px;
+        color: #fff;
+      }
+      .home-stats-grid {
+        max-width: 1100px; margin: 0 auto;
+        display: grid; grid-template-columns: repeat(2, 1fr); gap: 28px;
+        text-align: center;
+      }
+      .home-stat-value {
+        font-size: clamp(24px, 3.4vw, 34px); font-weight: 800;
+        letter-spacing: -0.03em; color: #FF6B35; margin-bottom: 6px;
+      }
+      .home-stat-label {
+        font-size: 12px; font-weight: 400; line-height: 1.5;
+        color: rgba(255,255,255,0.6);
+      }
+      @media (min-width: 720px) {
+        .home-stats-grid { grid-template-columns: repeat(4, 1fr); gap: 36px; }
+      }
+
       /* USP panel ────────────────────────────────────────────────────── */
       .usp-panel {
         max-width: 1100px;

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -116,20 +116,10 @@ export default function SiteHeader() {
         .site-nav a:hover { color: var(--brand-primary, #FF6B35); }
         .site-nav--desktop { display: none; }
         .site-actions { display: inline-flex; align-items: center; gap: 10px; }
-        .nav-cta {
-          display: inline-flex; align-items: center; gap: 7px;
-          background: var(--wa-green, #25D366); color: #fff;
-          padding: 8px 14px; border-radius: 999px; font-weight: 700; font-size: 13px;
-          white-space: nowrap;
-        }
-        .nav-cta:hover { background: #1EBE57; }
-        .nav-cta-mobile {
-          display: inline-flex; align-items: center; justify-content: center;
-          width: 38px; height: 38px; border-radius: 999px;
-          background: var(--wa-green, #25D366); color: #fff;
-          box-shadow: 0 2px 8px rgba(37,211,102,0.4);
-        }
-        .nav-cta-mobile:hover { background: #1EBE57; }
+        /* .nav-cta / .nav-cta-mobile styled in globals.css — styled-jsx
+           doesn't scope rules through next/link's <Link>, so the green
+           background and the desktop hide of .nav-cta-mobile silently
+           dropped when applied here. */
         .site-burger { display: inline-flex; flex-direction: column; justify-content: center; gap: 4px; width: 38px; height: 38px; padding: 0 8px; background: transparent; border: 1px solid #CBD5E1; border-radius: 10px; cursor: pointer; }
         .site-burger span { display: block; height: 2px; width: 100%; background: #16213E; border-radius: 2px; }
         .site-mobile-drawer { display: none; background: #fff; border-top: 1px solid #E2E8F0; padding: 14px 20px 18px; }
@@ -140,7 +130,6 @@ export default function SiteHeader() {
           .site-nav--desktop { display: inline-flex; }
           .site-burger { display: none; }
           .site-mobile-drawer { display: none !important; }
-          .nav-cta-mobile { display: none; }
         }
         @media (max-width: 879px) {
           :global(.nav-cta) { display: none !important; }


### PR DESCRIPTION
## Summary

### Header WhatsApp pill (was visually broken)
The desktop \`.nav-cta\` rendered without its green background and the mobile \`.nav-cta-mobile\` circle showed up at the same time on desktop. Root cause: styled-jsx scopes its rules by adding a hashed class to elements *inside the component's JSX* — but \`next/link\`'s \`<Link>\` renders the \`<a>\` internally and doesn't propagate that hash. So the rules silently failed to match.

Moved \`.nav-cta\` and \`.nav-cta-mobile\` rules to \`globals.css\` (with \`!important\` on the visibility breakpoints). Kept the \`:global(.nav-cta) { display: none }\` line inside SiteHeader's \`<style jsx>\` so the \`nav-cta-global-scope\` checklist rule stays green.

### Section order: Stats first, then USP
Pulled the Stats strip (6,000+ / 128 / RM30 / 4.9) out of \`HomePageClient\` and rendered it as a server section directly after the hero, before the USP panel. The USP card's negative-margin float now lands on the dark Stats background instead of leaving a cream stripe between the two sections.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vercel deploy --prod --yes\` aliased
- [ ] Visual: header shows a single green WhatsApp pill on desktop (icon + label) and a single circle on mobile; never both
- [ ] Visual: order after hero is Stats → USP → Products → ...; no cream stripe between Stats and USP

🤖 Generated with [Claude Code](https://claude.com/claude-code)