### PR TITLE
fix(sewa-motor): logo, dead nav link, hero photo bg, in-hero stats

### DIFF
--- a/projects/sewa-motor-malaysia/app/[locale]/page.tsx
+++ b/projects/sewa-motor-malaysia/app/[locale]/page.tsx
@@ -89,10 +89,7 @@ export default async function HomePage({
             </div>
           </div>
         </div>
-      </section>
-
-      <section className="home-stats" aria-label="Service highlights">
-        <div className="home-stats-grid">
+        <div className="home-hero-stats" aria-label="Service highlights">
           {stats.map((n) => (
             <div className="home-stat" key={n}>
               <div className="home-stat-value">{shared(`stats.value${n}` as 'stats.value1')}</div>

--- a/projects/sewa-motor-malaysia/components/PageStyles.tsx
+++ b/projects/sewa-motor-malaysia/components/PageStyles.tsx
@@ -28,10 +28,11 @@ export default function PageStyles() {
       }
       .home-hero-bg {
         position: absolute; inset: 0;
-        background-image: linear-gradient(135deg, rgba(22,33,62,0.85), rgba(15,23,42,0.95)), url('/og-image.jpg');
+        background-image:
+          linear-gradient(135deg, rgba(22,33,62,0.78) 0%, rgba(15,23,42,0.88) 55%, rgba(15,23,42,0.95) 100%),
+          url('https://static.wixstatic.com/media/d3104b_f1742c506a064da3af63f6b834024ad4~mv2.jpg');
         background-size: cover;
         background-position: center;
-        opacity: 0.6;
       }
       .home-hero h1 {
         font-size: clamp(30px, 4.6vw, 52px);
@@ -85,27 +86,26 @@ export default function PageStyles() {
         .home-hero-media { justify-content: flex-end; }
       }
 
-      /* Stats strip (sits between hero and USP) ───────────────────────── */
-      .home-stats {
-        background: #16213E;
-        padding: 56px 24px 72px;
-        color: #fff;
-      }
-      .home-stats-grid {
-        max-width: 1100px; margin: 0 auto;
-        display: grid; grid-template-columns: repeat(2, 1fr); gap: 28px;
+      /* Stats strip — sits at the bottom of the hero ───────────────────── */
+      .home-hero-stats {
+        position: relative; z-index: 1;
+        max-width: 1100px; margin: 48px auto 0;
+        display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px;
+        padding: 24px;
         text-align: center;
+        border-top: 1px solid rgba(255,255,255,0.12);
       }
       .home-stat-value {
-        font-size: clamp(24px, 3.4vw, 34px); font-weight: 800;
-        letter-spacing: -0.03em; color: #FF6B35; margin-bottom: 6px;
+        font-size: clamp(22px, 3.2vw, 32px); font-weight: 800;
+        letter-spacing: -0.03em; color: #FF6B35; margin-bottom: 4px;
+        line-height: 1;
       }
       .home-stat-label {
-        font-size: 12px; font-weight: 400; line-height: 1.5;
-        color: rgba(255,255,255,0.6);
+        font-size: 12px; font-weight: 400; line-height: 1.45;
+        color: rgba(255,255,255,0.7);
       }
       @media (min-width: 720px) {
-        .home-stats-grid { grid-template-columns: repeat(4, 1fr); gap: 36px; }
+        .home-hero-stats { grid-template-columns: repeat(4, 1fr); gap: 32px; padding: 28px 24px 8px; }
       }
 
       /* USP panel ────────────────────────────────────────────────────── */

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -16,11 +16,11 @@ export default function SiteHeader() {
       <div className="site-header-inner">
         <Link href={`/${locale}`} className="site-brand" aria-label="Sewa Motor Malaysia homepage">
           <span className="site-brand-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" width="22" height="22" fill="none">
-              <circle cx="7" cy="23" r="4" stroke="currentColor" strokeWidth="2" />
-              <circle cx="25" cy="23" r="4" stroke="currentColor" strokeWidth="2" />
-              <path d="M11 23h10M7 23l4-10h6l4 3h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M17 13l2-4h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <svg viewBox="0 0 32 32" width="28" height="28" fill="none">
+              <circle cx="8" cy="22" r="3.5" stroke="currentColor" strokeWidth="1.8" />
+              <circle cx="24" cy="22" r="3.5" stroke="currentColor" strokeWidth="1.8" />
+              <path d="M11.5 22h9M8 22l3.5-9h5.5l3.5 2.5h3.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M17 13l1.5-3.5h3.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
           </span>
           <span className="site-brand-text">Sewa Motor Malaysia</span>
@@ -28,7 +28,6 @@ export default function SiteHeader() {
         <nav className="site-nav site-nav--desktop" aria-label="Primary">
           <Link href={`/${locale}`}>{t('home')}</Link>
           <Link href={`/${locale}#products`}>{t('products')}</Link>
-          <Link href={`/${locale}#calculator`}>{t('calculator')}</Link>
           <Link href={`/${locale}#locations`}>{t('locations')}</Link>
           <Link href={`/${locale}/blog`}>{t('blog')}</Link>
         </nav>
@@ -79,7 +78,6 @@ export default function SiteHeader() {
         <nav className="site-mobile-nav" aria-label="Mobile primary">
           <Link href={`/${locale}`} onClick={close}>{t('home')}</Link>
           <Link href={`/${locale}#products`} onClick={close}>{t('products')}</Link>
-          <Link href={`/${locale}#calculator`} onClick={close}>{t('calculator')}</Link>
           <Link href={`/${locale}#locations`} onClick={close}>{t('locations')}</Link>
           <Link href={`/${locale}/blog`} onClick={close}>{t('blog')}</Link>
         </nav>


### PR DESCRIPTION
## Summary

- **Header logo**: synced the brand SVG paths to the favicon's exact paths and bumped the icon size from 22px to 28px so the motorcycle silhouette reads at header scale (previously looked like two indistinct circles).
- **Dead nav link**: dropped the "Calculator" item from desktop + mobile nav — there is no \`#calculator\` section on the homepage, so the anchor scrolled to nothing.
- **Hero background image + gradient**: swapped the local \`/og-image.jpg\` placeholder for the motorcycle-on-highway photo (the same one already used by the reviews section) layered under a 3-stop dark gradient (78 → 88 → 95% opacity) for headline contrast. Removed the redundant \`opacity: 0.6\` so the gradient owns the darkening.
- **Stats inside the hero**: moved the stats grid from a standalone dark section directly under the hero into the bottom of the hero itself, separated from the headline + photo block by a thin \`rgba(255,255,255,0.12)\` divider. Reads as a trust band closing the hero rather than a separate page section.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vercel deploy --prod --yes\` aliased to \`sewa-motor-malaysia.utopiaai.my\`
- [ ] Visual: header logo shows a clear motorcycle silhouette; nav reads "Home · Motorcycles · Locations · Blog"; hero shows a darkened motorcycle photo backdrop with 6,000+/128/RM30/4.9 stats embedded at the bottom of the hero; USP card follows directly after with no cream gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)