### PR TITLE
fix(sewa-motor): bolder filled brand icon + move .site-brand* to globals

### DIFF
--- a/projects/sewa-motor-malaysia/app/globals.css
+++ b/projects/sewa-motor-malaysia/app/globals.css
@@ -222,6 +222,30 @@ h1, h2, h3, h4, h5, h6 {
 /* ── USP panel (single container with 3 cells) ─────────────────────────── */
 .usp-panel-fallback { /* keep .usp-panel from PageStyles authoritative */ }
 
+/* ── Header brand mark — kept in globals because the brand link is a
+ *    next/link <Link> and styled-jsx scoping can miss its children. */
+.site-brand {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  font-size: 15px;
+  color: #16213E;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.site-brand-icon {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: #FF6B35;
+  box-shadow: 0 4px 12px rgba(255,107,53,0.35);
+}
+.site-brand-text { line-height: 1; }
+
 /* ── Header WhatsApp CTAs — kept in globals because styled-jsx in
  *    SiteHeader doesn't scope rules through next/link's <Link>. */
 .nav-cta {

--- a/projects/sewa-motor-malaysia/app/icon.svg
+++ b/projects/sewa-motor-malaysia/app/icon.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
   <rect width="32" height="32" rx="8" fill="#FF6B35"/>
-  <circle cx="8" cy="22" r="3.5" stroke="white" stroke-width="1.8" fill="none"/>
-  <circle cx="24" cy="22" r="3.5" stroke="white" stroke-width="1.8" fill="none"/>
-  <path d="M11.5 22h9M8 22l3.5-9h5.5l3.5 2.5h3.5" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <path d="M17 13l1.5-3.5h3.5" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="9" cy="22" r="5" fill="#fff"/>
+  <circle cx="9" cy="22" r="2" fill="#FF6B35"/>
+  <circle cx="23" cy="22" r="5" fill="#fff"/>
+  <circle cx="23" cy="22" r="2" fill="#FF6B35"/>
+  <path d="M12 19 L14 12 L19 12 L22 16 L26 16 L26 21 L22 21 L20 18 Z" fill="#fff"/>
+  <path d="M19 12 L22 8 L25 8" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/projects/sewa-motor-malaysia/components/SiteHeader.tsx
+++ b/projects/sewa-motor-malaysia/components/SiteHeader.tsx
@@ -16,11 +16,13 @@ export default function SiteHeader() {
       <div className="site-header-inner">
         <Link href={`/${locale}`} className="site-brand" aria-label="Sewa Motor Malaysia homepage">
           <span className="site-brand-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" width="28" height="28" fill="none">
-              <circle cx="8" cy="22" r="3.5" stroke="currentColor" strokeWidth="1.8" />
-              <circle cx="24" cy="22" r="3.5" stroke="currentColor" strokeWidth="1.8" />
-              <path d="M11.5 22h9M8 22l3.5-9h5.5l3.5 2.5h3.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M17 13l1.5-3.5h3.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            <svg viewBox="0 0 32 32" width="32" height="32">
+              <circle cx="9" cy="22" r="5" fill="#fff" />
+              <circle cx="9" cy="22" r="2" fill="#FF6B35" />
+              <circle cx="23" cy="22" r="5" fill="#fff" />
+              <circle cx="23" cy="22" r="2" fill="#FF6B35" />
+              <path d="M12 19 L14 12 L19 12 L22 16 L26 16 L26 21 L22 21 L20 18 Z" fill="#fff" />
+              <path d="M19 12 L22 8 L25 8" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
             </svg>
           </span>
           <span className="site-brand-text">Sewa Motor Malaysia</span>
@@ -96,19 +98,11 @@ export default function SiteHeader() {
           display: flex; align-items: center; justify-content: space-between;
           gap: 12px; padding: 12px 20px; min-height: 60px;
         }
-        .site-brand {
-          display: inline-flex; align-items: center; gap: 10px;
-          font-weight: 800; font-size: 15px; color: var(--brand-dark, #16213E);
-          white-space: nowrap; text-decoration: none;
-        }
-        .site-brand-icon {
-          display: inline-flex; align-items: center; justify-content: center;
-          width: 36px; height: 36px; border-radius: 10px;
-          background: var(--brand-primary, #FF6B35);
-          color: #fff;
-          box-shadow: 0 4px 12px rgba(255,107,53,0.35);
-        }
-        .site-brand-text { line-height: 1; }
+        /* .site-brand / .site-brand-icon / .site-brand-text are styled
+           in globals.css — styled-jsx adds its hash via JSX literal
+           tracking and the rules can fail to reach <span> descendants of
+           next/link's <Link> consistently. Keeping the actual paint in
+           globals.css matches how .nav-cta is handled. */
         .site-nav { display: inline-flex; gap: 24px; }
         .site-nav a { color: var(--brand-text, #1B2432); font-weight: 600; font-size: 14px; white-space: nowrap; }
         .site-nav a:hover { color: var(--brand-primary, #FF6B35); }


### PR DESCRIPTION
## Summary
The header brand mark was stroke-only line art at 1.8px width inside a 36px container — at header scale the strokes were too thin to read and the icon was barely identifiable. Two coordinated changes:

- **SiteHeader + \`app/icon.svg\`**: redesigned the motorcycle as filled solid white shapes. Wheels become solid discs with the orange brand colour punching through the hub, body is a chunky filled polygon, handlebar stays a short stroke for one accent line. Icon bumped from 28×28 to 32×32 filling a 40×40 container. Favicon mirrors the same paths so brand mark == favicon (per CLAUDE.md).
- **\`globals.css\`**: moved \`.site-brand\` / \`.site-brand-icon\` / \`.site-brand-text\` out of SiteHeader's \`<style jsx>\` block. Same root cause as the \`.nav-cta\` fix in PR #39 — these classes ride on elements inside a \`next/link\` \`<Link>\`, and styled-jsx's hashed-class scoping can fail to reach Link's child nodes, leaving the orange container unstyled.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vercel deploy --prod --yes\` aliased
- [ ] Visual: header brand mark shows a chunky, clearly readable motorcycle silhouette on the orange rounded square; favicon (browser tab) shows the same icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)