### PR TITLE
Site fixes: tablechair-rental (domain + UX), sewa-motor anchor, coldroom chrome

### DIFF
--- a/projects/coldroom-malaysia/app/[locale]/page.tsx
+++ b/projects/coldroom-malaysia/app/[locale]/page.tsx
@@ -16,6 +16,9 @@ import { ProductSchema } from '@/components/schema/ProductSchema';
 import { FAQSchema } from '@/components/schema/FAQSchema';
 
 const HERO_IMAGE = '/brand/hero.png';
+// Full-bleed cold-room scene behind the hero copy (sewa-excavator uses the same
+// photo-bg + overlay pattern). Darkened by the overlay below for text contrast.
+const HERO_SCENE = 'https://static.wixstatic.com/media/d3104b_390cb593d3624032ae4da7fe4603f080~mv2.jpg';
 
 const HERO_TIERS = [
   { slug: 'frozen-storage-minus-18', chip: '-18°C', tone: 'frost-deep' },
@@ -119,8 +122,12 @@ export default async function HomePage({
 
       {/* HERO — H1 + H2 + the image-role background live in the route file so
           the checklist sees them. Below the hero is <HomePageClient />. */}
-      <header style={{ position: 'relative', overflow: 'hidden', minHeight: '78vh', display: 'flex', alignItems: 'center', background: 'var(--grad-frost)' }}>
-        <div aria-hidden style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 80% 30%, rgba(201,229,242,0.18), transparent 50%), radial-gradient(circle at 15% 85%, rgba(79,177,214,0.22), transparent 45%)' }} />
+      <header style={{ position: 'relative', overflow: 'hidden', minHeight: '82vh', display: 'flex', alignItems: 'center', background: 'var(--steel-900)' }}>
+        {/* Full-bleed cold-room scene photo */}
+        <div aria-hidden style={{ position: 'absolute', inset: 0, backgroundImage: `url(${HERO_SCENE})`, backgroundSize: 'cover', backgroundPosition: 'center' }} />
+        {/* Dark frost overlay so the white hero copy stays legible over the photo */}
+        <div aria-hidden style={{ position: 'absolute', inset: 0, background: 'linear-gradient(100deg, rgba(11,61,92,0.94) 0%, rgba(11,61,92,0.78) 42%, rgba(19,24,34,0.55) 100%)' }} />
+        <div aria-hidden style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 80% 30%, rgba(79,177,214,0.18), transparent 55%)' }} />
         <div className="section-container" style={{ position: 'relative', zIndex: 2, padding: '72px 24px', display: 'grid', gridTemplateColumns: '1.1fr 1fr', gap: 48, alignItems: 'center' }}>
           <div className="hero-copy">
             <span className="eyebrow" style={{ color: 'var(--cold-amber-glow)' }}>{t('hero.eyebrow')}</span>

--- a/projects/coldroom-malaysia/app/[locale]/page.tsx
+++ b/projects/coldroom-malaysia/app/[locale]/page.tsx
@@ -134,7 +134,7 @@ export default async function HomePage({
             <h1 style={{ color: '#fff', marginTop: 14, marginBottom: 22, textShadow: '0 4px 24px rgba(11,61,92,0.45)' }}>
               {t.rich('hero.h1', { accent: (chunks) => <span style={{ color: 'var(--cold-amber-glow)' }}>{chunks}</span> })}
             </h1>
-            <span aria-hidden style={{ display: 'block', height: 3, width: 72, background: 'var(--cold-amber)', borderRadius: 3, marginBottom: 18 }} />
+            <span aria-hidden className="hero-rule" style={{ display: 'block', height: 3, width: 72, background: 'var(--cold-amber)', borderRadius: 3, marginBottom: 18 }} />
             <h2 style={{ color: 'rgba(255,255,255,0.96)', fontWeight: 600, marginBottom: 30, maxWidth: 620 }}>
               {t('hero.h2')}
             </h2>
@@ -145,7 +145,7 @@ export default async function HomePage({
               <a href="#products" className="btn btn-ghost-frost">{t('hero.secondaryCta')}</a>
             </div>
             {/* Temperature tiers — top two are WhatsApp quick-rent CTAs */}
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginBottom: 22 }}>
+            <div className="hero-chips" style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginBottom: 22 }}>
               <TrackedWhatsAppLink href={waRedirect(locale, '-18°C Frozen Storage')} className="temp-chip frost-deep">
                 -18°C <span style={{ fontWeight: 500 }}>{t('hero.tempLabels.frozen-storage-minus-18')}</span>
               </TrackedWhatsAppLink>
@@ -158,7 +158,7 @@ export default async function HomePage({
                 </a>
               ))}
             </div>
-            <div style={{ display: 'flex', gap: 22, flexWrap: 'wrap', alignItems: 'center', marginTop: 12, paddingTop: 22, borderTop: '1px solid rgba(255,255,255,0.18)' }}>
+            <div className="hero-microstats" style={{ display: 'flex', gap: 22, flexWrap: 'wrap', alignItems: 'center', marginTop: 12, paddingTop: 22, borderTop: '1px solid rgba(255,255,255,0.18)' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#fff', fontSize: 13 }}>
                 <span style={{ fontWeight: 800, fontSize: 18 }}>256,800+</span> <span style={{ opacity: 0.82 }}>{t('hero.microStats.tonnes')}</span>
               </div>

--- a/projects/coldroom-malaysia/app/globals.css
+++ b/projects/coldroom-malaysia/app/globals.css
@@ -238,13 +238,24 @@ p, li { line-height: var(--leading-relaxed); color: var(--steel-500); }
 }
 
 /* ============================================
-   FOMO BANNER + NAV — both sticky, stacked
+   FOMO BANNER + NAV — banner scrolls away, nav sticks to the very top.
+   Matches sewa-excavator: the FOMO bar is a normal block at the top of the
+   page (visible in the first viewport) and scrolls off, while only the nav is
+   sticky at top:0. This avoids coupling the nav offset to the banner height —
+   on mobile the banner wraps to 2–3 lines, so a fixed --fomo-height offset
+   left the nav (and the mobile drawer) mis-positioned.
    ============================================ */
-.fomo-bar { background: var(--steel-900); border-bottom: 2px solid var(--cold-amber); position: sticky; top: 0; z-index: 60; }
-.site-nav { position: sticky; top: var(--fomo-height, 44px); z-index: 55; background: #fff; border-bottom: 1px solid var(--steel-100); }
+.fomo-bar { background: var(--steel-900); border-bottom: 2px solid var(--cold-amber); position: relative; z-index: 60; }
+.site-nav { position: sticky; top: 0; z-index: 55; background: #fff; border-bottom: 1px solid var(--steel-100); }
 .site-nav.scrolled { box-shadow: var(--shadow-nav); }
 .fomo-text-enter { animation: fomoFade 320ms var(--ease-out); }
 .fomo-countdown { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum'; font-weight: 700; letter-spacing: 0.04em; }
+/* Compact the banner on phones so it stays ~2 lines instead of sprawling
+   (sewa-excavator shrinks its FOMO copy the same way on mobile). */
+@media (max-width: 640px) {
+  .fomo-bar .fomo-inner { padding: 7px 16px !important; gap: 8px 12px !important; font-size: 12px; flex-wrap: wrap; }
+  .fomo-bar .fomo-inner > div { font-size: 12px !important; gap: 6px !important; }
+}
 
 @keyframes fomoFade { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
 

--- a/projects/coldroom-malaysia/components/FomoBanner.tsx
+++ b/projects/coldroom-malaysia/components/FomoBanner.tsx
@@ -32,7 +32,7 @@ export default function FomoBanner() {
   return (
     <div className="fomo-bar">
       <div
-        className="section-container"
+        className="section-container fomo-inner"
         style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16, padding: '10px 24px', minHeight: 44 }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, color: '#fff', fontSize: 13, flex: 1, justifyContent: 'center' }}>

--- a/projects/coldroom-malaysia/components/HomePageClient.tsx
+++ b/projects/coldroom-malaysia/components/HomePageClient.tsx
@@ -176,7 +176,7 @@ function ServiceCard({ product, locale, waHref }: { product: Product; locale: st
     <article
       ref={ref as React.Ref<HTMLElement>}
       id={product.slug}
-      className="card"
+      className="card service-split-grid"
       style={{ display: 'grid', gridTemplateColumns: '1fr 1.4fr', overflow: 'hidden', border: 0, maxWidth: 1080, margin: '0 auto', boxShadow: 'var(--shadow-lg)' }}
     >
       {/* Visual side */}

--- a/projects/coldroom-malaysia/components/PageStyles.tsx
+++ b/projects/coldroom-malaysia/components/PageStyles.tsx
@@ -18,9 +18,10 @@ export default function PageStyles() {
       .mobile-menu-btn { display: none; }
 
       @media (max-width: 900px) {
+        /* sewa-excavator mobile header order: burger (left) · logo (centre) · language (right) */
         .nav-links-desktop { display: none !important; }
-        .lang-desktop { display: none !important; }
-        .mobile-menu-btn { display: inline-flex !important; }
+        .mobile-menu-btn { display: inline-flex !important; order: -1; }
+        .nav-logo { flex: 1 1 auto !important; justify-content: center !important; }
         .hero-photo { display: none !important; }
         .hero-cta-row { justify-content: center; }
         .nav-cta { display: none !important; }

--- a/projects/coldroom-malaysia/components/PageStyles.tsx
+++ b/projects/coldroom-malaysia/components/PageStyles.tsx
@@ -43,6 +43,9 @@ export default function PageStyles() {
         .bento-grid > div:first-child { grid-column: span 2 !important; grid-row: span 1 !important; }
         .footer-grid { grid-template-columns: 1fr 1fr !important; }
         .states-grid { grid-template-columns: 1fr !important; }
+        /* Product card: stack the price/visual side above the temp-options side
+           so the 2-col split doesn't overflow the viewport on phones. */
+        .service-split-grid { grid-template-columns: 1fr !important; }
       }
       @media (max-width: 640px) {
         .gallery-grid { grid-template-columns: repeat(2, 1fr) !important; }

--- a/projects/coldroom-malaysia/components/PageStyles.tsx
+++ b/projects/coldroom-malaysia/components/PageStyles.tsx
@@ -24,6 +24,11 @@ export default function PageStyles() {
         .nav-logo { flex: 1 1 auto !important; justify-content: center !important; }
         .hero-photo { display: none !important; }
         .hero-cta-row { justify-content: center; }
+        /* Centre the hero chip row + micro-stats on mobile so they match the
+           centred hero copy (sewa-excavator centres all hero elements). */
+        .hero-chips { justify-content: center !important; }
+        .hero-microstats { justify-content: center !important; }
+        .hero-rule { margin-left: auto !important; margin-right: auto !important; }
         .nav-cta { display: none !important; }
       }
       @media (max-width: 768px) {
@@ -31,6 +36,11 @@ export default function PageStyles() {
         .hero-copy { text-align: center; }
         .hero-copy .eyebrow { display: inline-block; }
         .usp-panel { grid-template-columns: 1fr !important; }
+        /* Centre each USP item (icon + text) on mobile instead of left-aligning,
+           and drop the desktop column-separator border/padding that would shift
+           the 2nd/3rd cells out of alignment when stacked. */
+        .usp-cell { justify-content: center !important; }
+        .usp-panel .usp-cell + .usp-cell { border-left: 0 !important; padding-left: 0 !important; }
         .stats-grid { grid-template-columns: repeat(2, 1fr) !important; gap: 28px !important; }
         .stats-strip { grid-template-columns: repeat(2, 1fr) !important; gap: 16px !important; }
         .stats-strip > :first-child { grid-column: 1 / -1; border-right: 0 !important; padding-right: 0 !important; padding-bottom: 4px; border-bottom: 1px solid rgba(255,255,255,0.18); text-align: center; }

--- a/projects/coldroom-malaysia/components/SiteFooter.tsx
+++ b/projects/coldroom-malaysia/components/SiteFooter.tsx
@@ -4,6 +4,10 @@ import { BrandMark } from '@/components/BrandMark';
 import { siteConfig } from '@/config/site';
 import { locations } from '@/config/locations';
 
+// Footer layout mirrors the canonical sewa-excavator SiteFooter: a brand block
+// (logo + tagline) beside a column group (Products / Top Locations / Resources),
+// centred on mobile, with a bottom copyright bar. Re-themed to the cold-chain
+// palette (steel-900 surface, cold-amber accent).
 const FOOTER_TIERS = [
   'frozen-storage-minus-18',
   'freezer-minus-5-to-minus-10',
@@ -17,60 +21,90 @@ export async function SiteFooter({ locale }: { locale: string }) {
   const t = await getTranslations({ locale });
 
   return (
-    <footer className="surface-steel-dark" style={{ padding: '60px 0 28px' }}>
-      <div className="section-container footer-grid" style={{ display: 'grid', gridTemplateColumns: '1.6fr 1fr 1fr 1fr', gap: 36 }}>
-        <div>
-          <Link href={`/${locale}`} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <BrandMark size={36} />
-            <span style={{ fontWeight: 800, color: '#fff', fontSize: 17 }}>{t('nav.brandName')}</span>
-          </Link>
-          <p style={{ marginTop: 14, color: 'rgba(255,255,255,0.6)', fontSize: 13, maxWidth: 320 }}>{t('footer.tagline')}</p>
-          <div style={{ marginTop: 16, height: 2, width: 60, background: 'var(--cold-amber)', borderRadius: 2 }} />
-        </div>
-        <div>
-          <div style={{ fontWeight: 700, color: '#fff', fontSize: 13, marginBottom: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>{t('footer.cols.products')}</div>
-          <ul style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {FOOTER_TIERS.map((slug) => (
-              <li key={slug}>
-                <Link href={`/${locale}#cold-room-rental`} style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13 }}>
-                  {t(`hero.tempLabels.${slug}`)}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <div style={{ fontWeight: 700, color: '#fff', fontSize: 13, marginBottom: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>{t('footer.cols.cities')}</div>
-          <ul style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {FOOTER_CITIES.map((slug) => {
-              const c = locations.find((l) => l.slug === slug);
-              if (!c) return null;
-              const display = locale === 'zh' ? c.name_zh : locale === 'ms' ? (c.name_ms ?? c.name) : c.name;
-              return (
-                <li key={slug}>
-                  <Link href={`/${locale}/${siteConfig.productSlug}/${slug}`} style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13 }}>
-                    {display}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-        <div>
-          <div style={{ fontWeight: 700, color: '#fff', fontSize: 13, marginBottom: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>{t('footer.cols.languages')}</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {(['en', 'ms', 'zh'] as const).map((l) => (
-              <Link key={l} href={`/${l}`} style={{ color: 'rgba(255,255,255,0.7)', fontSize: 13 }}>
-                {l === 'en' ? 'English' : l === 'ms' ? 'Bahasa Melayu' : '中文'}
-              </Link>
-            ))}
+    <footer className="site-footer">
+      <div className="section-container">
+        <div className="footer-top">
+          <div className="footer-brand">
+            <Link href={`/${locale}`} className="footer-mark" aria-label={t('nav.brandName')}>
+              <BrandMark size={40} />
+              <span className="footer-brand-name">{t('nav.brandName')}</span>
+            </Link>
+            <p className="footer-tag">{t('footer.tagline')}</p>
+            <span aria-hidden className="footer-accent" />
+          </div>
+
+          <div className="footer-cols">
+            <div>
+              <h6>{t('footer.cols.products')}</h6>
+              <ul>
+                {FOOTER_TIERS.map((slug) => (
+                  <li key={slug}>
+                    <Link href={`/${locale}#cold-room-rental`}>{t(`hero.tempLabels.${slug}`)}</Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h6>{t('footer.cols.cities')}</h6>
+              <ul>
+                {FOOTER_CITIES.map((slug) => {
+                  const c = locations.find((l) => l.slug === slug);
+                  if (!c) return null;
+                  const display = locale === 'zh' ? c.name_zh : locale === 'ms' ? (c.name_ms ?? c.name) : c.name;
+                  return (
+                    <li key={slug}>
+                      <Link href={`/${locale}/${siteConfig.productSlug}/${slug}`}>{display}</Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+            <div>
+              <h6>{t('footer.cols.resources')}</h6>
+              <ul>
+                <li><Link href={`/${locale}/blog`}>{t('nav.blog')}</Link></li>
+                <li><Link href={`/${locale}#faq`}>{t('nav.faq')}</Link></li>
+                <li><Link href={`/${locale}#locations`}>{t('nav.locations')}</Link></li>
+              </ul>
+            </div>
           </div>
         </div>
+
+        <div className="footer-bottom">
+          <p className="footer-copy">© {new Date().getFullYear()} {t('nav.brandName')}. {t('footer.rights')}</p>
+          <p className="footer-copy">{t('footer.poweredBy')}</p>
+        </div>
       </div>
-      <div className="section-container" style={{ marginTop: 36, paddingTop: 18, borderTop: '1px solid rgba(255,255,255,0.08)', display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
-        <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: 12 }}>© {new Date().getFullYear()} {t('nav.brandName')}. {t('footer.rights')}</span>
-        <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: 12 }}>{t('footer.poweredBy')}</span>
-      </div>
+
+      <style>{`
+        .site-footer { background: var(--steel-900); color: rgba(255,255,255,0.7); padding: 72px 0 32px; }
+        .footer-top { display: grid; grid-template-columns: 1fr; gap: 40px; }
+        @media (min-width: 768px) { .footer-top { grid-template-columns: 1fr 2fr; gap: 64px; } }
+        .footer-brand { display: flex; flex-direction: column; gap: 16px; max-width: 340px; }
+        .footer-mark { display: inline-flex; align-items: center; gap: 10px; }
+        .footer-brand-name { font-weight: 800; color: #fff; font-size: 18px; letter-spacing: -0.02em; }
+        .footer-tag { margin: 0; color: rgba(255,255,255,0.6); font-size: 14px; line-height: 1.6; }
+        .footer-accent { display: block; height: 2px; width: 60px; background: var(--cold-amber); border-radius: 2px; }
+        .footer-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 28px; }
+        .footer-cols h6 { font-weight: 700; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: #fff; margin: 0 0 14px; }
+        .footer-cols ul { list-style: none; padding: 0; margin: 0; }
+        .footer-cols li { margin-bottom: 10px; }
+        .footer-cols a { color: rgba(255,255,255,0.7); font-size: 14px; transition: color 200ms var(--ease-out); }
+        .footer-cols a:hover { color: var(--cold-amber-glow); }
+        .footer-bottom { margin-top: 56px; padding-top: 24px; border-top: 1px solid rgba(255,255,255,0.10); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; font-size: 12px; color: rgba(255,255,255,0.5); }
+        .footer-copy { margin: 0; }
+        @media (max-width: 767px) {
+          .site-footer { padding: 48px 0 24px; }
+          .footer-top { gap: 28px; }
+          .footer-top, .footer-brand, .footer-bottom { text-align: center; align-items: center; }
+          .footer-brand { max-width: none; gap: 12px; }
+          .footer-mark { justify-content: center; }
+          .footer-accent { align-self: center; }
+          .footer-cols { display: block; column-count: 2; column-gap: 24px; text-align: center; }
+          .footer-cols > div { break-inside: avoid; display: inline-block; width: 100%; margin: 0 0 24px; }
+          .footer-bottom { margin-top: 32px; padding-top: 18px; justify-content: center; }
+        }
+      `}</style>
     </footer>
   );
 }

--- a/projects/coldroom-malaysia/components/SiteHeader.tsx
+++ b/projects/coldroom-malaysia/components/SiteHeader.tsx
@@ -83,24 +83,29 @@ export default function SiteHeader({ activeBlog = false }: { activeBlog?: boolea
             </button>
           </div>
         </div>
+        {/* Mobile drawer is an absolute child of the sticky nav, anchored at its
+            bottom edge (top: 100%). It follows the nav wherever it sticks, so it
+            can never be mis-offset by the FOMO banner height (sewa-excavator
+            attaches the drawer to the header the same way). */}
+        {open && (
+          <div
+            style={{
+              position: 'absolute', top: '100%', left: 0, right: 0,
+              background: '#fff', borderBottom: '1px solid var(--steel-100)',
+              boxShadow: 'var(--shadow-md)', padding: 12,
+              display: 'flex', flexDirection: 'column', gap: 4,
+              maxHeight: 'calc(100vh - 68px)', overflowY: 'auto',
+            }}
+          >
+            {links.map((l) => (
+              <Link key={l.href} href={l.href} onClick={() => setOpen(false)} style={{ padding: '12px 16px', fontSize: 15, fontWeight: 500, color: 'var(--steel-700)', borderRadius: 8 }}>
+                {l.label}
+              </Link>
+            ))}
+            <div style={{ padding: 8 }}><LanguageSwitcher /></div>
+          </div>
+        )}
       </nav>
-      {open && (
-        <div
-          style={{
-            position: 'fixed', top: 'calc(var(--fomo-height, 44px) + 68px)', left: 0, right: 0,
-            background: '#fff', borderBottom: '1px solid var(--steel-100)',
-            boxShadow: 'var(--shadow-md)', padding: 12, zIndex: 49,
-            display: 'flex', flexDirection: 'column', gap: 4,
-          }}
-        >
-          {links.map((l) => (
-            <Link key={l.href} href={l.href} onClick={() => setOpen(false)} style={{ padding: '12px 16px', fontSize: 15, fontWeight: 500, color: 'var(--steel-700)', borderRadius: 8 }}>
-              {l.label}
-            </Link>
-          ))}
-          <div style={{ padding: 8 }}><LanguageSwitcher /></div>
-        </div>
-      )}
       {/* Mobile hides the header WhatsApp CTA so it never overlaps the language
           dropdown. :global() so the rule reaches the .nav-cta <a> from styled-jsx. */}
       <style jsx>{`

--- a/projects/coldroom-malaysia/components/SiteHeader.tsx
+++ b/projects/coldroom-malaysia/components/SiteHeader.tsx
@@ -37,7 +37,15 @@ export default function SiteHeader({ activeBlog = false }: { activeBlog?: boolea
     <>
       <nav className={`site-nav${scrolled ? ' scrolled' : ''}`}>
         <div className="section-container" style={{ display: 'flex', alignItems: 'center', gap: 24, height: 68 }}>
-          <Link href={`/${locale}`} style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }} aria-label={siteConfig.brandName}>
+          <button
+            aria-label="menu"
+            className="mobile-menu-btn"
+            onClick={() => setOpen((o) => !o)}
+            style={{ display: 'none', alignItems: 'center', justifyContent: 'center', width: 40, height: 40, borderRadius: 8, color: 'var(--frost-deep)', flexShrink: 0 }}
+          >
+            <MenuIcon open={open} />
+          </button>
+          <Link href={`/${locale}`} className="nav-logo" style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }} aria-label={siteConfig.brandName}>
             <BrandMark size={36} />
             <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.05 }}>
               <span style={{ fontWeight: 800, fontSize: 16, letterSpacing: '-0.02em', color: 'var(--frost-deep)', whiteSpace: 'nowrap' }}>{t('brandName')}</span>
@@ -61,8 +69,8 @@ export default function SiteHeader({ activeBlog = false }: { activeBlog?: boolea
               </Link>
             ))}
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <div className="lang-desktop"><LanguageSwitcher /></div>
+          <div className="nav-actions" style={{ display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+            <div className="nav-lang"><LanguageSwitcher /></div>
             <a
               href={waHref}
               target="_blank"
@@ -73,14 +81,6 @@ export default function SiteHeader({ activeBlog = false }: { activeBlog?: boolea
             >
               <WaIcon size={14} /> {t('ctaShort')}
             </a>
-            <button
-              aria-label="menu"
-              className="mobile-menu-btn"
-              onClick={() => setOpen((o) => !o)}
-              style={{ display: 'none', alignItems: 'center', justifyContent: 'center', width: 40, height: 40, borderRadius: 8, color: 'var(--frost-deep)' }}
-            >
-              <MenuIcon open={open} />
-            </button>
           </div>
         </div>
         {/* Mobile drawer is an absolute child of the sticky nav, anchored at its

--- a/projects/coldroom-malaysia/messages/en.json
+++ b/projects/coldroom-malaysia/messages/en.json
@@ -289,7 +289,8 @@
     "cols": {
       "products": "Cold Rooms",
       "cities": "Top Cities",
-      "languages": "Languages"
+      "languages": "Languages",
+      "resources": "Resources"
     },
     "quickLinks": "Quick Links",
     "contact": "Contact",

--- a/projects/coldroom-malaysia/messages/en.json
+++ b/projects/coldroom-malaysia/messages/en.json
@@ -78,7 +78,7 @@
     "eyebrow": "Cheapest Cold Chain Logistic in Malaysia",
     "heading": "Our Cold Room Rental Service",
     "subheading": "One trusted cold room rental service. Four temperature options to fit your goods. Same-day delivery across all 13 Peninsular states.",
-    "priceFrom": "From RM {price} / pallet per day",
+    "priceFrom": "From RM {price}",
     "imageAltTemplate": "{model} cold room rental in Malaysia",
     "perPalletDay": "per pallet / day",
     "cta": "WhatsApp Quote",

--- a/projects/coldroom-malaysia/messages/ms.json
+++ b/projects/coldroom-malaysia/messages/ms.json
@@ -78,7 +78,7 @@
     "eyebrow": "Logistik Rantaian Sejuk Termurah di Malaysia",
     "heading": "Perkhidmatan Sewa Cold Room Kami",
     "subheading": "Satu perkhidmatan sewa cold room dipercayai. Empat pilihan suhu untuk barang anda. Penghantaran hari yang sama di 13 negeri Semenanjung.",
-    "priceFrom": "Dari RM {price} / palet sehari",
+    "priceFrom": "Dari RM {price}",
     "imageAltTemplate": "Sewa cold room {model} di Malaysia",
     "perPalletDay": "sehari / palet",
     "cta": "Sebut Harga",

--- a/projects/coldroom-malaysia/messages/ms.json
+++ b/projects/coldroom-malaysia/messages/ms.json
@@ -289,7 +289,8 @@
     "cols": {
       "products": "Cold Room",
       "cities": "Bandar Utama",
-      "languages": "Bahasa"
+      "languages": "Bahasa",
+      "resources": "Sumber"
     },
     "quickLinks": "Pautan Pantas",
     "contact": "Hubungi",

--- a/projects/coldroom-malaysia/messages/zh.json
+++ b/projects/coldroom-malaysia/messages/zh.json
@@ -289,7 +289,8 @@
     "cols": {
       "products": "冷库",
       "cities": "主要城市",
-      "languages": "语言"
+      "languages": "语言",
+      "resources": "资源"
     },
     "quickLinks": "快速链接",
     "contact": "联系",

--- a/projects/coldroom-malaysia/messages/zh.json
+++ b/projects/coldroom-malaysia/messages/zh.json
@@ -78,7 +78,7 @@
     "eyebrow": "马来西亚最便宜冷链物流",
     "heading": "我们的冷库出租服务",
     "subheading": "一项可靠的冷库出租服务。四种温度选项满足您的货物需求。覆盖 13 个西马州属，当天送达。",
-    "priceFrom": "RM {price} 起 / 每托盘每天",
+    "priceFrom": "RM {price} 起",
     "imageAltTemplate": "{model}冷库出租，马来西亚",
     "perPalletDay": "每托盘 / 天",
     "cta": "WhatsApp 报价",

--- a/projects/sewa-motor-malaysia/app/globals.css
+++ b/projects/sewa-motor-malaysia/app/globals.css
@@ -19,7 +19,7 @@
 }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; scroll-padding-top: 84px; }
 
 body {
   font-family: var(--font);

--- a/projects/tablechair-rental-malaysia/app/[locale]/page.tsx
+++ b/projects/tablechair-rental-malaysia/app/[locale]/page.tsx
@@ -70,12 +70,6 @@ export default async function HomePage({
   const tShared = await getTranslations({ locale, namespace: 'shared' })
   const waDefault = waRedirect(locale, tShared('whatsappMessageDefault'))
 
-  // Featured packages get a direct WhatsApp quick-rent chip in the hero so the
-  // top products carry an above-the-fold conversion path (every product card in
-  // the grid below also has its own WhatsApp CTA).
-  const featuredChipClass =
-    'inline-flex items-center gap-1.5 rounded-full bg-[#25D366] px-3.5 py-1.5 text-[13px] font-semibold text-white shadow-[0_6px_16px_-8px_rgba(37,211,102,0.6)] hover:bg-[#1EB85A]'
-
   return (
     <>
       <PageStyles />
@@ -153,47 +147,6 @@ export default async function HomePage({
                   {tHome('hero.secondaryCta')}
                 </Link>
               </div>
-
-              {core.length > 0 && (
-                <div className="mt-5 flex flex-wrap items-center gap-2">
-                  {core[0] && (
-                    <a
-                      href={waRedirect(locale, core[0].name)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={featuredChipClass}
-                      style={{ transition: 'background-color 180ms ease' }}
-                    >
-                      <span className="h-1.5 w-1.5 rounded-full bg-white" aria-hidden="true" />
-                      {core[0].name}
-                    </a>
-                  )}
-                  {core[1] && (
-                    <a
-                      href={waRedirect(locale, core[1].name)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={featuredChipClass}
-                      style={{ transition: 'background-color 180ms ease' }}
-                    >
-                      <span className="h-1.5 w-1.5 rounded-full bg-white" aria-hidden="true" />
-                      {core[1].name}
-                    </a>
-                  )}
-                  {core[2] && (
-                    <a
-                      href={waRedirect(locale, core[2].name)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={featuredChipClass}
-                      style={{ transition: 'background-color 180ms ease' }}
-                    >
-                      <span className="h-1.5 w-1.5 rounded-full bg-white" aria-hidden="true" />
-                      {core[2].name}
-                    </a>
-                  )}
-                </div>
-              )}
 
               <p className="mt-7 flex flex-wrap items-center gap-4 text-xs font-medium text-[#111111]/70">
                 <span>{tHome('hero.trust')}</span>

--- a/projects/tablechair-rental-malaysia/components/FomoBanner.tsx
+++ b/projects/tablechair-rental-malaysia/components/FomoBanner.tsx
@@ -11,8 +11,8 @@ export default async function FomoBanner({ locale }: { locale: Locale }) {
   const waDefault = waRedirect(locale, tShared('whatsappMessageDefault'))
 
   return (
-    <div className="relative z-50 overflow-hidden bg-[#111111] py-2.5 text-center text-white">
-      <div className="mx-auto flex max-w-5xl items-center justify-center gap-3 px-4 text-[13px] sm:gap-5 sm:text-[14px]">
+    <div className="relative z-50 overflow-hidden bg-[#111111] py-2.5 text-left text-white">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 text-[13px] sm:gap-5 sm:text-[14px]">
         <p className="inline-flex items-center gap-2">
           <span className="relative flex h-2 w-2" aria-hidden="true">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#FDD835] opacity-75" />

--- a/projects/tablechair-rental-malaysia/components/PageShell.tsx
+++ b/projects/tablechair-rental-malaysia/components/PageShell.tsx
@@ -410,21 +410,29 @@ export default async function PageShell({
                     </p>
                   )}
 
-                  <div className="mt-5 overflow-hidden rounded-2xl border border-[#FDD835]/25 bg-[#FFF9C4]/60 text-sm">
-                    <p className="flex items-center justify-between px-4 py-2.5">
-                      <span className="text-[#111111]/60">
-                        {tHome('products.plainLabel')}
-                      </span>
-                      <span className="font-semibold text-[#111111]">{rentalDisplay}</span>
-                    </p>
-                    <div className="h-px bg-[#FDD835]/35" />
-                    <p className="flex items-center justify-between px-4 py-2.5">
-                      <span className="text-[#111111]/60">
-                        {tHome('products.withCoverLabel')}
-                      </span>
-                      <span className="font-semibold text-[#111111]">{saleDisplay}</span>
-                    </p>
-                  </div>
+                  {(p.rental_price != null || p.sale_price != null) && (
+                    <div className="mt-5 overflow-hidden rounded-2xl border border-[#FDD835]/25 bg-[#FFF9C4]/60 text-sm">
+                      {p.rental_price != null && (
+                        <p className="flex items-center justify-between px-4 py-2.5">
+                          <span className="text-[#111111]/60">
+                            {tHome('products.plainLabel')}
+                          </span>
+                          <span className="font-semibold text-[#111111]">{rentalDisplay}</span>
+                        </p>
+                      )}
+                      {p.rental_price != null && p.sale_price != null && (
+                        <div className="h-px bg-[#FDD835]/35" />
+                      )}
+                      {p.sale_price != null && (
+                        <p className="flex items-center justify-between px-4 py-2.5">
+                          <span className="text-[#111111]/60">
+                            {tHome('products.withCoverLabel')}
+                          </span>
+                          <span className="font-semibold text-[#111111]">{saleDisplay}</span>
+                        </p>
+                      )}
+                    </div>
+                  )}
 
                   <div className="mt-auto pt-5">
                     <WAButton

--- a/projects/tablechair-rental-malaysia/components/SiteFooter.tsx
+++ b/projects/tablechair-rental-malaysia/components/SiteFooter.tsx
@@ -18,9 +18,9 @@ export default async function SiteFooter({ locale }: { locale: Locale }) {
     <footer id="contact" className="relative bg-[#0A0A0A] text-[#FFFEF8]">
       <div className="h-[3px] w-full bg-gradient-to-r from-transparent via-[#FDD835] to-transparent opacity-70" />
       <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
-        <div className="grid gap-10 md:grid-cols-4">
+        <div className="grid gap-10 text-center md:grid-cols-4">
           <div className="md:col-span-1">
-            <p className="flex items-center gap-2.5">
+            <p className="flex items-center justify-center gap-2.5">
               <KKMark className="h-10 w-10" />
               <span className="text-lg font-extrabold tracking-tight">Kak Kenduri</span>
             </p>
@@ -66,7 +66,7 @@ export default async function SiteFooter({ locale }: { locale: Locale }) {
             <p className="mt-5 text-[15px] leading-[1.7] text-[#FFFEF8]/70">
               {tFoot('getInTouchSub')}
             </p>
-            <div className="mt-4">
+            <div className="mt-4 flex justify-center">
               <a
                 href={waDefault}
                 target="_blank"
@@ -77,12 +77,12 @@ export default async function SiteFooter({ locale }: { locale: Locale }) {
                 {tNav('whatsapp')}
               </a>
             </div>
-            <div className="mt-5">
+            <div className="mt-5 flex justify-center">
               <LanguageSwitcher />
             </div>
           </div>
         </div>
-        <div className="mt-12 flex flex-col items-start justify-between gap-3 border-t border-[#FFFEF8]/15 pt-6 text-xs text-[#FFFEF8]/60 md:flex-row">
+        <div className="mt-12 flex flex-col items-center justify-center gap-3 border-t border-[#FFFEF8]/15 pt-6 text-center text-xs text-[#FFFEF8]/60">
           <p>{tFoot('legal', { year: String(new Date().getFullYear()) })}</p>
         </div>
       </div>

--- a/projects/tablechair-rental-malaysia/config/site.ts
+++ b/projects/tablechair-rental-malaysia/config/site.ts
@@ -5,8 +5,8 @@
 export const siteConfig = {
   brandName: 'Kak Kenduri',
   legalName: 'Kak Kenduri Sdn. Bhd.',
-  domain: 'tablechair-rental-malaysia.utopiaai.my',
-  url: 'https://tablechair-rental-malaysia.utopiaai.my',
+  domain: 'tablechairrentals.my',
+  url: 'https://tablechairrentals.my',
   productSlug: 'table-chair-rental',
   fallbackPhone: '60174287801',
   email: 'kerusimejamy@gmail.com',

--- a/projects/tablechair-rental-malaysia/deploy-url.txt
+++ b/projects/tablechair-rental-malaysia/deploy-url.txt
@@ -1,1 +1,1 @@
-https://tablechair-rental-malaysia.utopiaai.my
+https://tablechairrentals.my

--- a/projects/tablechair-rental-malaysia/lib/webcore.ts
+++ b/projects/tablechair-rental-malaysia/lib/webcore.ts
@@ -85,7 +85,9 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    // Strip port and a leading www. so www.<domain> resolves the same phone/
+    // leads rows as the apex domain (rows are keyed on the apex host).
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }


### PR DESCRIPTION
Accumulated fixes from the build session across three live sites. All changes are already deployed to production and verified.

## tablechair-rental-malaysia
- Point canonical domain at `tablechairrentals.my` (config had an empty utopiaai.my domain with zero Supabase rows → products/blog now render, phone reads from DB)
- Strip `www.` in host lookup so `www.` resolves the DB phone
- Remove product-name "quick-rent chips" from the hero
- Hide the "Plain"/"With Cover" price rows when a product has no such price
- Center-align the footer
- Left-align the FOMO banner text

## sewa-motor-malaysia
- `scroll-padding-top: 84px` so nav anchors (`#products`, `#locations`) land below the sticky header instead of under it

## coldroom-malaysia
- Match header/hero/footer layout + mobile chrome to the canonical sewa-excavator pattern
- Stack product card on mobile to kill horizontal overflow
- Remove duplicated pallet/day unit in hero price

🤖 Generated with [Claude Code](https://claude.com/claude-code)