### PR TITLE
fix(roller-shutter): strip www. from host so phone lookup hits DB

### DIFF
--- a/projects/roller-shutter-malaysia/lib/webcore.ts
+++ b/projects/roller-shutter-malaysia/lib/webcore.ts
@@ -90,7 +90,12 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    // Strip port AND a leading `www.` — the site canonicalises to the www host
+    // (rollershutterdoors.my → www.rollershutterdoors.my), but the webcore
+    // phone_numbers / company_websites rows are keyed to the bare apex domain.
+    // Without this, the www host misses the DB lookup and falls back to the
+    // config placeholder number.
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }


### PR DESCRIPTION
## Problem
The roller-shutter live site was showing the operator's placeholder number (`60174287801`) instead of the client's real WhatsApp number.

Root cause: the Vercel domain canonicalises apex → www (`rollershutterdoors.my` 301s to `www.rollershutterdoors.my`), so every visitor's request arrives with host `www.rollershutterdoors.my`. `getHostDomain()` stripped only the port, and the webcore `phone_numbers` / `company_websites` rows are keyed to the **bare apex** domain — so the lookup missed and fell back to `config.fallbackPhone`.

## Fix
Strip a leading `www.` in `getHostDomain()` so www + apex both resolve the existing apex-keyed DB row.

```ts
return host.replace(/:\d+$/, '').replace(/^www\./, '')
```

## Verification
Deployed to production and confirmed live — both hosts now serve the DB number:
- `https://rollershutterdoors.my/ms/redirect-whatsapp-1` → `wa.me/60106684688`
- `https://www.rollershutterdoors.my/ms/redirect-whatsapp-1` → `wa.me/60106684688`

## Follow-up (not in this PR)
`config/site.ts` still points at the old domain `rollershutter-malaysia.utopiaai.my` (now 404) — the domain migration to `rollershutterdoors.my` is still incomplete (affects products/blog queries + checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)