### PR TITLE
fix(phone): normalize www. host so DB phone lookup never falls back (all 12 sites)

### DIFF
--- a/projects/cat-rumah-malaysia/lib/webcore.ts
+++ b/projects/cat-rumah-malaysia/lib/webcore.ts
@@ -89,7 +89,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/coldroom-malaysia/lib/webcore.ts
+++ b/projects/coldroom-malaysia/lib/webcore.ts
@@ -135,7 +135,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/electric-wheelchair-malaysia/lib/webcore.ts
+++ b/projects/electric-wheelchair-malaysia/lib/webcore.ts
@@ -92,7 +92,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/electrician-24-hour/lib/webcore.ts
+++ b/projects/electrician-24-hour/lib/webcore.ts
@@ -85,7 +85,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/katering-auntyrokiah/lib/webcore.ts
+++ b/projects/katering-auntyrokiah/lib/webcore.ts
@@ -143,7 +143,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/katilhospital-24jam/lib/webcore.ts
+++ b/projects/katilhospital-24jam/lib/webcore.ts
@@ -146,7 +146,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers();
     const host = h.get('host') || h.get('x-forwarded-host') || '';
-    return host.replace(/:\d+$/, '');
+    return host.replace(/:\d+$/, '').replace(/^www\./, '');
   } catch {
     return '';
   }

--- a/projects/oxihome-malaysia/lib/webcore.ts
+++ b/projects/oxihome-malaysia/lib/webcore.ts
@@ -124,7 +124,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers();
     const host = h.get('host') || h.get('x-forwarded-host') || '';
-    return host.replace(/:\d+$/, '');
+    return host.replace(/:\d+$/, '').replace(/^www\./, '');
   } catch {
     return '';
   }

--- a/projects/roller-shutter-malaysia/lib/webcore.ts
+++ b/projects/roller-shutter-malaysia/lib/webcore.ts
@@ -90,7 +90,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/service-aircond-malaysia/lib/webcore.ts
+++ b/projects/service-aircond-malaysia/lib/webcore.ts
@@ -92,7 +92,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/sewa-excavator/lib/webcore.ts
+++ b/projects/sewa-excavator/lib/webcore.ts
@@ -134,7 +134,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers();
     const host = h.get('host') || h.get('x-forwarded-host') || '';
-    return host.replace(/:\d+$/, '');
+    return host.replace(/:\d+$/, '').replace(/^www\./, '');
   } catch {
     return '';
   }

--- a/projects/sewa-motor-malaysia/lib/webcore.ts
+++ b/projects/sewa-motor-malaysia/lib/webcore.ts
@@ -76,7 +76,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/projects/skylift-malaysia/lib/webcore.ts
+++ b/projects/skylift-malaysia/lib/webcore.ts
@@ -141,7 +141,7 @@ async function getHostDomain(): Promise<string> {
   try {
     const h = await headers()
     const host = h.get('host') || h.get('x-forwarded-host') || ''
-    return host.replace(/:\d+$/, '')
+    return host.replace(/:\d+$/, '').replace(/^www\./, '')
   } catch {
     return ''
   }

--- a/utopia-wizard/lib/checklist.ts
+++ b/utopia-wizard/lib/checklist.ts
@@ -1908,6 +1908,20 @@ const DEPLOYMENT: Check[] = [
         if (!baseUrls.includes(u)) baseUrls.push(u)
       }
 
+      // Also probe the www/apex counterpart of every candidate. Sites commonly
+      // canonicalise apex -> www (or vice versa); if the phone row is keyed to
+      // one host and the site serves the other, the lookup silently falls back
+      // to the config placeholder number. Probing both catches that mismatch
+      // even when the redirect chain would otherwise hide it.
+      for (const u of [...baseUrls]) {
+        try {
+          const url = new URL(u)
+          url.host = url.host.startsWith('www.') ? url.host.slice(4) : `www.${url.host}`
+          const alt = url.origin
+          if (!baseUrls.includes(alt)) baseUrls.push(alt)
+        } catch { /* non-URL deployUrl — skip */ }
+      }
+
       const dbPhones = (phones ?? []).filter((p) => p.is_active).map((p) => p.phone_number)
       const status = await checkLiveDbConnection({
         baseUrls: Array.from(new Set(baseUrls)),

--- a/utopia-wizard/lib/runChecklist.ts
+++ b/utopia-wizard/lib/runChecklist.ts
@@ -77,12 +77,22 @@ async function expandCandidates(info: ProjectInfo): Promise<ProjectInfo> {
     }
   }
 
-  // (b) Fallback phone → phone_numbers lookup, but only when the phone is
-  // unique to ONE website. Shared/template phones (e.g. the same number
-  // across 6 sister sites) would otherwise pollute the candidate list.
+  // (b) Fallback phone → phone_numbers lookup. `fallbackPhone` is a *placeholder*
+  // that is frequently a shared operator number, so a unique phone→website match
+  // does NOT prove that website is THIS project's — e.g. roller-shutter-malaysia
+  // borrowed katilhospital's operator number `60174287801`, which is registered
+  // in phone_numbers under exactly one site (`katilhospitalmurah.com.my`), and the
+  // old `length === 1` guard therefore pulled that unrelated katilhospital domain
+  // into roller-shutter's candidate list. Only trust the phone match when the
+  // resolved domain is corroborated by a slug keyword (it plausibly belongs to
+  // this site). This keeps the "a site's own unique phone reveals its custom
+  // domain" case working while rejecting borrowed/shared numbers.
   if (info.fallbackPhone) {
     const byPhone = await findRegisteredDomainsByPhone(info.fallbackPhone)
-    if (byPhone.length === 1) extras.add(byPhone[0])
+    if (byPhone.length === 1) {
+      const stem = byPhone[0].toLowerCase().replace(/[^a-z0-9]/g, '')
+      if (slugKeywords(info.slug).some((kw) => stem.includes(kw))) extras.add(byPhone[0])
+    }
   }
 
   if (extras.size === 0) return info


### PR DESCRIPTION
## Problem
`getHostDomain()` stripped only the port. On sites that canonicalise apex → `www.` (or vice versa), the runtime host is `www.<domain>` but the `phone_numbers` / `company_websites` rows are keyed to the **bare apex** — so the lookup missed and the site silently served `config.fallbackPhone`. On **9 of 13 sites** that fallback is a shared operator placeholder (`60174287801`), so a single lookup miss puts the operator's personal number on a live client site. This is what happened to **roller-shutter**.

## Scope (root-cause, all sites)
- **`getHostDomain()` now strips a leading `www.`** in all 12 project `lib/webcore.ts`. `sewa-excavator` is the scaffold reference (`scripts/scaffold-site.ts` clones it), so **future sites inherit the fix**; `tablechair` already had it.
- **Monitor hardening** (`utopia-wizard/lib/checklist.ts`): the `live-db-connected` check now also probes the `www.`/apex counterpart of every candidate URL, so a host/DB-key mismatch is caught instead of hiding behind a redirect. (`fallback` status is already a hard fail.)

## Docs (in working tree, not this commit)
`docs/full-website-setup.md` gains two rules — the `getHostDomain()` normalization requirement and "**`fallbackPhone` must be the client's own number, never a shared operator number**". These sit alongside other pending edits to that file, so they land when it's next committed.

## Follow-ups (separate)
- Backfill the same `www.` fix into the **standalone `atyn-utopia/*` repos** (what actually deploys + what the monitor scans) and redeploy the affected live sites.
- Replace the shared `60174287801` fallback on the 9 sites with each client's real number.

Supersedes #51 (includes the same roller-shutter change plus the other 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)