### PR TITLE
fix(ci): check the wizard out with a GitHub App token, not the dead deploy key

### DIFF
--- a/.github/workflows/guardrails-gate.yml
+++ b/.github/workflows/guardrails-gate.yml
@@ -29,16 +29,25 @@ jobs:
         with:
           fetch-depth: 0   # need the merge base to diff changed projects
 
+      - name: Mint a read-only token for the wizard repo
+        id: wizard-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WIZARD_APP_ID }}
+          private-key: ${{ secrets.WIZARD_APP_PRIVATE_KEY }}
+          owner: utopiagrowth
+          repositories: utopia-wizard
+
       # The wizard is no longer vendored here — check it out at the same path so
       # `working-directory: utopia-wizard` and gate.ts's `../projects` lookup
-      # keep resolving. Read-only deploy key, see monitor-scan.yml.
+      # keep resolving. GitHub App installation token, see monitor-scan.yml.
       - name: Check out the wizard (single source of truth)
         uses: actions/checkout@v4
         with:
-          repository: atyn-utopia/utopia-wizard
+          repository: utopiagrowth/utopia-wizard
           ref: main
           path: utopia-wizard
-          ssh-key: ${{ secrets.WIZARD_DEPLOY_KEY }}
+          token: ${{ steps.wizard-token.outputs.token }}
           persist-credentials: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/monitor-scan.yml
+++ b/.github/workflows/monitor-scan.yml
@@ -4,14 +4,20 @@ name: monitor-scan
 # monitor_snapshots table. The deployed Utopia Fairy monitor reads from there.
 #
 # The wizard is NOT vendored in this repo any more. It lives in
-# atyn-utopia/utopia-wizard (the repo Vercel deploys) and is checked out here at
+# utopiagrowth/utopia-wizard (the repo Vercel deploys) and is checked out here at
 # the same `utopia-wizard/` path, so every path in this workflow keeps resolving
 # exactly as before. The copy that used to live here had drifted 30 files from
 # the deployed one in BOTH directions — the scanner graded with 106 checks while
 # the app shipped 115, and neither was complete. One checkout, one engine.
 #
-# Auth: WIZARD_DEPLOY_KEY is the private half of a READ-ONLY deploy key on
-# atyn-utopia/utopia-wizard — scoped to that one repo, and it never expires.
+# Auth: a GitHub App installation token, minted per run and valid for an hour.
+# The previous read-only deploy key died when the wizard moved from the
+# atyn-utopia org to utopiagrowth, which disables deploy keys for every repo it
+# owns — the key is still listed there, permanently greyed out, and checkout
+# failed with a misleading "Repository not found" for a week. An App is the one
+# credential the org policy allows that also has no expiry to lapse and belongs
+# to no single person: WIZARD_APP_ID + WIZARD_APP_PRIVATE_KEY, installed on
+# utopiagrowth/utopia-wizard alone with Contents: read.
 
 on:
   schedule:
@@ -34,15 +40,24 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Mint a read-only token for the wizard repo
+        id: wizard-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WIZARD_APP_ID }}
+          private-key: ${{ secrets.WIZARD_APP_PRIVATE_KEY }}
+          owner: utopiagrowth
+          repositories: utopia-wizard
+
       # The scanner clones every connected repo itself, so this job needs the
       # wizard and nothing else from this repository.
       - name: Check out the wizard (single source of truth)
         uses: actions/checkout@v4
         with:
-          repository: atyn-utopia/utopia-wizard
+          repository: utopiagrowth/utopia-wizard
           ref: main
           path: utopia-wizard
-          ssh-key: ${{ secrets.WIZARD_DEPLOY_KEY }}
+          token: ${{ steps.wizard-token.outputs.token }}
           persist-credentials: false
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Closes #56

`monitor-scan` has failed every run since 2026-08-27 09:34Z — 40 seconds in, at the checkout step, so the scanner never ran and the monitor's snapshots are a week stale. `guardrails-gate` carries the identical broken step, so it is fixed here too.

### Root cause

The wizard repo moved from `atyn-utopia` to `utopiagrowth`. Two things broke at once:

- both workflows still name `atyn-utopia/utopia-wizard`, which no longer exists under that owner
- both authenticate with an SSH deploy key, and `utopiagrowth` disables deploy keys for every repo it owns — the key is still listed on the repo, greyed out ("Disabled by utopiagrowth"), with only a Delete button

An SSH key does not follow a transfer redirect the way the REST API does, which is why the log said `ERROR: Repository not found.` instead of a permission error — it read like a deleted repo rather than a revoked credential.

### Change

Each workflow mints a GitHub App installation token with `actions/create-github-app-token@v2`, scoped with `owner: utopiagrowth` / `repositories: utopia-wizard`, and hands it to `actions/checkout` as `token:`. The checkout `repository:` moves to the new owner. Everything downstream — the `utopia-wizard/` path, the npm cache key, `working-directory` — is untouched.

An App was chosen over a fine-grained PAT (no expiry to lapse silently, not tied to one person's account) and over re-enabling deploy keys org-wide (that policy change would apply to every repo in `utopiagrowth`, not just this one).

### Required before merge

Two new secrets on this repo, from a GitHub App in the `utopiagrowth` org with **Contents: read**, installed on `utopia-wizard` only:

- `WIZARD_APP_ID`
- `WIZARD_APP_PRIVATE_KEY`

`WIZARD_DEPLOY_KEY` becomes dead weight once this lands and can be deleted, along with the disabled key on the wizard repo.

### Verification

`guardrails-gate` runs on this PR (its own path is in the trigger's `paths`), so its check on this PR exercises the new token against the real repo — a green gate here is the proof the App credential works, before merge. `monitor-scan` is then confirmed with a `workflow_dispatch` run after merge, and the wizard's Rescan button should reach "Scan Complete".

🤖 Generated with [Claude Code](https://claude.com/claude-code)