### PR TITLE
fix(ci): pass the App credentials to the scanner step

### DIFF
--- a/.github/workflows/monitor-scan.yml
+++ b/.github/workflows/monitor-scan.yml
@@ -78,6 +78,11 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # Decrypts each user's stored GitHub token so their repo can be cloned.
           WIZARD_TOKEN_KEY: ${{ secrets.WIZARD_TOKEN_KEY }}
+          # Fallback for repos a user's token cannot see. The wizard signs users
+          # in through a classic OAuth App, and utopiagrowth refuses those — so
+          # without this the scanner loses every private repo that org holds.
+          WIZARD_APP_ID: ${{ secrets.WIZARD_APP_ID }}
+          WIZARD_APP_PRIVATE_KEY: ${{ secrets.WIZARD_APP_PRIVATE_KEY }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
         run: npm run scan-repos


### PR DESCRIPTION
Closes #58

#57 fixed the *checkout*; the scanner that runs afterwards still fails 40 of its 43 repos, because it clones as each repo's owner and `utopiagrowth` refuses the classic OAuth App those stored tokens come from.

utopiagrowth/utopia-wizard#2 makes the scanner fall back to an App installation token for any repo the owner's token cannot reach. It reads `WIZARD_APP_ID` and `WIZARD_APP_PRIVATE_KEY`; this PR passes them into the `Run scanner (connected repos)` step. Without it that change is inert.

No new secrets — both were added to this repo for #56.

### Merge order

utopiagrowth/utopia-wizard#2 first: this workflow checks the wizard out from its `main`, so the variables would otherwise arrive at a scanner that doesn't read them yet. That order is safe either way — an unread env var changes nothing.

### Verification

The scanner change was dry-run against all 43 rows locally: 42 ok, the single failure being a repo whose owner token that machine cannot decrypt and which CI has always scanned successfully (3 ok / 40 failed before the change). Confirmation for this PR is a `monitor-scan` run reaching `success` with 43 ok / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)