### PR TITLE
chore(guardrails): regenerate after dropping the font-family checks

### DIFF
--- a/docs/guardrails.html
+++ b/docs/guardrails.html
@@ -61,9 +61,9 @@
 </header>
 <div class="wrap">
   <div class="stats">
-    <div class="stat"><div class="n">115</div><div class="l">Total rules</div></div>
+    <div class="stat"><div class="n">113</div><div class="l">Total rules</div></div>
     <div class="stat block"><div class="n">62</div><div class="l">Blocking</div></div>
-    <div class="stat adv"><div class="n">53</div><div class="l">Advisory</div></div>
+    <div class="stat adv"><div class="n">51</div><div class="l">Advisory</div></div>
     <div class="stat"><div class="n">11</div><div class="l">Categories</div></div>
   </div>
 
@@ -293,22 +293,10 @@
       </table>
     </section>
     <section class="group" data-group="Layout &amp; Design">
-      <h2>Layout &amp; Design <span class="gcount">41 rules · 17 blocking</span></h2>
+      <h2>Layout &amp; Design <span class="gcount">39 rules · 17 blocking</span></h2>
       <table>
         <thead><tr><th>Severity</th><th>Rule</th><th>Check id</th><th>Doc</th></tr></thead>
         <tbody>
-      <tr class="rule" data-sev="advisory" data-text="uses inter or plus jakarta sans font-house-style">
-        <td><span class="badge sev-adv">advisory</span></td>
-        <td class="rule-name">Uses Inter or Plus Jakarta Sans</td>
-        <td><code>font-house-style</code></td>
-        <td><a href="full-website-setup.md#layout--design-checklist-mandatory-before-gate-1" target="_blank" rel="noopener">docs ↗</a></td>
-      </tr>
-      <tr class="rule" data-sev="advisory" data-text="no forbidden serif display fonts no-forbidden-serifs">
-        <td><span class="badge sev-adv">advisory</span></td>
-        <td class="rule-name">No forbidden serif display fonts</td>
-        <td><code>no-forbidden-serifs</code></td>
-        <td><a href="full-website-setup.md#layout--design-checklist-mandatory-before-gate-1" target="_blank" rel="noopener">docs ↗</a></td>
-      </tr>
       <tr class="rule" data-sev="blocking" data-text="favicon (app/icon.svg) favicon">
         <td><span class="badge sev-block">BLOCKING</span></td>
         <td class="rule-name">Favicon (app/icon.svg)</td>


### PR DESCRIPTION
Closes #60

`docs/guardrails.html` is generated from the wizard's check registry, and utopiagrowth/utopia-wizard#4 removed `font-house-style` and `no-forbidden-serifs`. Regenerated with `npm run guardrails`: 115 rules → 113 (62 blocking, 51 advisory).

Generated output only — the diff is the two removed rows and the total. Until this lands, the `Guardrails page is up to date` step fails on every PR against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)