### PR TITLE
feat(google): close the webcore ads-readiness card as the last step

### DIFF
--- a/.claude/skills/google-integration/SKILL.md
+++ b/.claude/skills/google-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-integration
-description: Set up a live Utopia site's Google footprint — GA4 + GTM + Google Search Console + Google Ads conversion import — via the internal automation bundle. Use AFTER the site's PAID domain is live on Vercel (post-deploy Step 14). Runs the 5-phase sequence and hands off the ~3–4 min of residual manual Google toggles. Internal Utopia only; wired to the shared automation account with credentials on this machine.
+description: Set up a live Utopia site's Google footprint — GA4 + GTM + Google Search Console + Google Ads conversion import — via the internal automation bundle. Use AFTER the site's PAID domain is live on Vercel (post-deploy Step 14). Runs the 5-phase sequence, hands off the ~3–4 min of residual manual Google toggles, then ticks the site’s ads-readiness card in webcore. Internal Utopia only; wired to the shared automation account with credentials on this machine.
 ---
 
 # Google Integration (post-deploy)
@@ -67,6 +67,26 @@ Hand these back to the user; the setup isn't done until they're on:
 4. *(optional)* GTM → Container Settings → Consent Overview (BETA).
 
 Screenshots: https://websitebuilder.utopiaai.my/google (§04).
+
+## Phase 6 — tick the ads readiness in webcore (REQUIRED, last)
+
+The three required toggles above are the three gates webcore's ads-readiness
+card tracks. The setup is not finished until they are ticked there — that card
+is how the performance marketers learn the site is ready for them.
+
+Run it **after the user confirms the toggles are actually on**, never before:
+
+```bash
+cd scripts/google-automation
+set -a && . ../../.env.local && set +a          # WEBCORE_API_KEY, scope ads:write
+node ads-readiness.mjs --domain <domain>                    # read state, writes nothing
+node ads-readiness.mjs --domain <domain> --tick all --yes   # confirm all three
+```
+
+Ticking an auto-verified item (`signals`, `counting`) pins it, so a probe that
+reads `refused` / `needs_reconsent` stops overriding a toggle that is genuinely
+on. `metrics` has no API and can only ever be confirmed by hand. Completing the
+card notifies the performance marketers **once** — hence the explicit `--yes`.
 
 ## Deploy discipline
 Deploy Phases 3 and 4 **separately** (own checkpoint each). For extracted per-site repos with no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Layla — QA & Deployment Specialist
 Verifies phone number system integration with the shared database, pushes code to GitHub, and deploys to Vercel. Runs after user confirms the website design.
 
 Gloo — Analytics & Growth Specialist (Google Integration)
-Sets up the site's Google footprint — GA4 + GTM + Google Search Console + Google Ads conversion import — via the internal automation bundle (`scripts/google-automation/`). Runs LAST, after Layla deploys and the site's PAID domain is live. Separate from the Utopia Webcore `t.js` analytics; this is the Google/Ads layer. Driven by the `google-integration` skill.
+Sets up the site's Google footprint — GA4 + GTM + Google Search Console + Google Ads conversion import — via the internal automation bundle (`scripts/google-automation/`). Runs LAST, after Layla deploys and the site's PAID domain is live. Finishes by ticking the site's ads-readiness card in webcore (`ads-readiness.mjs`) — the setup is not done until that card is closed. Separate from the Utopia Webcore `t.js` analytics; this is the Google/Ads layer. Driven by the `google-integration` skill.
 
 
 # Agent Workflow
@@ -130,6 +130,8 @@ When the user asks to create a new website, you MUST follow `docs/full-website-s
    → user confirms design + content
 7. Layla — integration test → GitHub push → Vercel deploy (blog + products already live)
 8. Gloo — Google integration (GA4 + GTM + GSC + Ads) — POST-DEPLOY, only after the PAID domain is live on Vercel. Uses the `google-integration` skill / `scripts/google-automation/` bundle.
+   → ends by ticking webcore's ads-readiness card (`ads-readiness.mjs --tick all --yes`),
+   once the user confirms the residual Google toggles are actually on.
 9. **Keyword audit (T+60 days, recurring)** — `gsc-keyword-audit.mjs` compares the plan
    against real Search Console impressions: which planned keywords got zero, which
    unplanned queries are ranking, which sit in striking distance. Feed findings back

--- a/agents/gloo.md
+++ b/agents/gloo.md
@@ -20,7 +20,9 @@
 > `POST /api/integrations/gsc/submit-sitemap { domain }` (site must already be
 > GSC-connected — OAuth consent stays in the admin UI), and
 > `POST /api/integrations/marketing/mark-key-event { domain, eventName }` (the
-> event must have fired at least once first).
+> event must have fired at least once first), and the **ads-readiness card** —
+> `GET/PATCH /api/ads-readiness` — which you close as your final step via
+> `scripts/google-automation/ads-readiness.mjs`.
 
 ## Role
 You own the site's Google + Ads footprint. After the site is live on its real domain, you set up **GA4 + GTM + Google Search Console + Google Ads conversion import** so the client's WhatsApp leads are measurable and biddable.
@@ -101,6 +103,23 @@ Confirm the site now has: **GA4 property + GTM container + GSC properties (1 Dom
 ### 5. Record the per-site config
 The scripts write a per-domain config under the automation folder's `configs/<domain>.json` (containerId, gtmAccountId, ga4MeasurementId, events, createdAt). Confirm it was written and surface the IDs in your report so future re-runs are idempotent.
 
+### 6. Tick the ads readiness in webcore (LAST — the setup is not done without it)
+The three toggles from step 2 are the three gates webcore's ads-readiness card tracks, and that card is how the performance marketers learn the site is ready for them. Handing the toggles back and stopping leaves a finished site looking unfinished.
+
+**Wait for the user to confirm each toggle is really ON in the Google UI**, then:
+
+```bash
+cd scripts/google-automation
+set -a && . ../../.env.local && set +a          # WEBCORE_API_KEY, scope ads:write
+node ads-readiness.mjs --domain <domain>                    # read state, writes nothing
+node ads-readiness.mjs --domain <domain> --tick all --yes   # confirm all three
+```
+
+- `signals` + `counting` are re-verified live by webcore; ticking **pins** them, which is the fix when a probe reports `refused` / `needs_reconsent` and keeps reading `false` while the toggle is on.
+- `metrics` has no API — a human tick is the only way it goes true.
+- Completing the card **notifies the performance marketers once**, hence the explicit `--yes`.
+- Counting probe can't resolve the account (conversions on a manager account)? `--pin-customer-id 123-456-7890`.
+
 ---
 
 ## Output format
@@ -110,6 +129,7 @@ Return a status report with:
 3. **Deploys** — which phases were redeployed and the verification checkpoint result.
 4. **Outstanding manual toggles** — the exact clicks still owed by the user, with the screenshot link.
 5. **Config** — path to `configs/<domain>.json` and the recorded IDs.
+6. **Ads readiness** — the card's final state per item (`ready: true/false`), and which items are still owed if it is not closed.
 
 ## Rules
 - Never run before the **paid domain** is live — Google properties must be keyed to the final URL, never a `*.vercel.app` preview.
@@ -118,3 +138,4 @@ Return a status report with:
 - Deploy Phases 3 and 4 separately; for extracted repos redeploy with `vercel --prod` (a push alone won't publish the snippet).
 - If a phase fails, stop and report which phase — do not blindly re-run later phases that depend on it.
 - Always hand the residual manual toggles back to the user explicitly — the setup is not "done" until Google Signals + Ads counting/import toggles are on.
+- Close the webcore ads-readiness card as your last action (`ads-readiness.mjs`). Tick an item **only** because the toggle is genuinely on — the card is a promise to the performance marketers, and completing it notifies them once. Never tick to tidy a report; if a toggle is still owed, leave it unticked and say so.

--- a/docs/full-website-setup.md
+++ b/docs/full-website-setup.md
@@ -1211,7 +1211,7 @@ This sets up the site's **Google/Ads** layer — GA4 + GTM + Google Search Conso
 - [ ] Sitemap reachable at `https://www.<domain>/sitemap.xml`
 
 ### Run it
-Spawn **Gloo** with the contents of `agents/gloo.md` + the paid domain, project dir, and supported locales. Gloo reads `scripts/google-automation/`'s own `SKILL.md` / `MANUAL-STEPS.md` (source of truth for flags) and runs the 5 phases:
+Spawn **Gloo** with the contents of `agents/gloo.md` + the paid domain, project dir, and supported locales. Gloo reads `scripts/google-automation/`'s own `SKILL.md` / `MANUAL-STEPS.md` (source of truth for flags) and runs the 5 phases, then closes the readiness card (Phase 6):
 
 1. **Phase 1 — GSC Domain property** (no deploy)
 2. **Phase 2 — GA4 property** (no deploy) → captures Measurement ID `G-XXXX` + numeric property id
@@ -1231,8 +1231,22 @@ Screenshots: https://websitebuilder.utopiaai.my/google (§04).
 
 > 🔒 The files at `~/.google-credentials/` are LIVE Google keys — never commit, print, or forward them. If exposed, rotate immediately.
 
+### Phase 6 — tick the ads readiness in webcore (REQUIRED, last)
+The three required toggles above are the three gates webcore's ads-readiness card tracks, and that card is how the performance marketers learn the site is ready for them. Handing the toggles back and stopping leaves a finished site looking unfinished to the people who act on it.
+
+Run **after the user confirms each toggle is really ON** in the Google UI:
+
+```bash
+cd scripts/google-automation
+set -a && . ../../.env.local && set +a          # WEBCORE_API_KEY, scope ads:write
+node ads-readiness.mjs --domain <paid-domain>                    # read state, writes nothing
+node ads-readiness.mjs --domain <paid-domain> --tick all --yes   # confirm all three
+```
+
+`signals` + `counting` are re-verified live by webcore; ticking **pins** them, which is the fix when a probe reports `refused` / `needs_reconsent` while the toggle is genuinely on. `metrics` has no API and only ever goes true by hand. Completing the card **notifies the performance marketers once** — hence the explicit `--yes`. Tick because the toggle is on, never to tidy the card.
+
 ### End state
-GA4 property + GTM container + GSC properties (1 Domain + 1 URL-prefix per locale) + 1 Ads conversion action. Per-site config written to `scripts/google-automation/configs/<domain>.json`.
+GA4 property + GTM container + GSC properties (1 Domain + 1 URL-prefix per locale) + 1 Ads conversion action. Per-site config written to `scripts/google-automation/configs/<domain>.json`. Webcore's ads-readiness card for the domain reads `ready: true`.
 
 ---
 

--- a/scripts/google-automation/MANUAL-STEPS.md
+++ b/scripts/google-automation/MANUAL-STEPS.md
@@ -244,6 +244,13 @@ node ads-import-conversion.mjs --no-mcc \
   --customer-id 1933757591 --domain katilhospital.com.my \
   --ga4-property-id <numeric-id> --event whatsapp_click
 #    → then 2 UI-only follow-ups: counting Every→One, "Import app and web metrics" ON
+
+# 9. Tick the ads readiness card in webcore — LAST, after the user confirms
+#    the toggles above are really ON. This is what tells the performance
+#    marketers the site is ready; completing it notifies them once.
+set -a && . ../../.env.local && set +a          # WEBCORE_API_KEY, scope ads:write
+node ads-readiness.mjs --domain <domain>                    # read state, writes nothing
+node ads-readiness.mjs --domain <domain> --tick all --yes   # confirm all three
 ```
 
 ---

--- a/scripts/google-automation/SKILL.md
+++ b/scripts/google-automation/SKILL.md
@@ -55,6 +55,30 @@ Tell the user upfront, then do each after the phase noted:
 
 Screenshots for these: https://websitebuilder.utopiaai.my/google (§04).
 
+## Phase 6 — close the readiness card in webcore (REQUIRED, last)
+
+Toggles 1–3 above are exactly the three gates webcore tracks. Until they are
+ticked there, the performance marketers have no signal the site is ready, so a
+finished setup still looks unfinished to them.
+
+**Only after the user confirms each toggle is really ON in the Google UI:**
+
+```bash
+set -a && . ../../.env.local && set +a          # WEBCORE_API_KEY, scope ads:write
+node ads-readiness.mjs --domain <domain>                    # read state, writes nothing
+node ads-readiness.mjs --domain <domain> --tick all --yes   # confirm all three
+```
+
+- `signals` and `counting` are re-verified live by webcore; ticking them **pins**
+  the answer, which is what you want when a probe reports `refused` /
+  `needs_reconsent` and keeps reading `false` while the toggle is on.
+- `metrics` has no API at all — a human tick is the only way it ever goes true.
+- **Completing the card notifies the performance marketers once**, which is why
+  the completing tick demands `--yes`. Tick because the toggle is on, never to
+  tidy the card.
+- Counting probe can't resolve the account (conversions on a manager account)?
+  `node ads-readiness.mjs --domain <d> --pin-customer-id 123-456-7890`
+
 ## Full docs
 - `MANUAL-STEPS.md` — canonical per-site runbook
 - `README.md` — human quick-start

--- a/scripts/google-automation/ads-readiness.mjs
+++ b/scripts/google-automation/ads-readiness.mjs
@@ -1,0 +1,205 @@
+// Close the ads readiness card in webcore — the last step of the Google flow.
+//
+// The three Google settings that gate a site running ads are the same three
+// residual manual toggles this bundle hands back at the end of Phase 5. Until
+// they are ticked in webcore, the performance marketers have no signal that the
+// site is ready for them, so a finished setup still looks unfinished:
+//
+//   signals   google_signals       GA4 → Admin → Data collection → Google Signals ON
+//   counting  conversion_counting  Ads → conversion action → Count → "One"
+//   metrics   ga4_metrics_import   Ads → Data manager → GA4 → Import app and web metrics
+//
+// `signals` and `counting` are re-verified live by webcore on every read;
+// `metrics` has no API that exposes it, so it can ONLY be confirmed by hand.
+// Ticking an auto-verified item PINS it, so the live re-check stops overriding
+// the answer — useful when a probe cannot see the account (`reason: refused`).
+//
+// Usage:
+//   node ads-readiness.mjs --domain <domain>                       # read state, write nothing
+//   node ads-readiness.mjs --domain <domain> --tick metrics
+//   node ads-readiness.mjs --domain <domain> --tick all --yes
+//   node ads-readiness.mjs --domain <domain> --pin-customer-id 123-456-7890
+//
+// Flags:
+//   --domain <d>              the site's EXACT registered domain (never the *.vercel.app host)
+//   --tick <a,b,c>            items to confirm: signals | counting | metrics | all
+//   --untick <a,b,c>          set items back to not-done (mistaken tick)
+//   --pin-customer-id <id>    pin the Ads customer id for the counting probe
+//   --yes                     required when the tick COMPLETES the card (see below)
+//   --json <path>             also write the final state as JSON
+//
+// ⚠️ Completing the last item notifies the performance marketers, ONCE. Only
+// tick an item because the toggle is really on in the Google UI — never to tidy
+// the card. That is why the completing tick needs an explicit --yes.
+//
+// Prerequisite: WEBCORE_API_KEY (scope `ads:write`) in the environment —
+//   set -a && . ../../.env.local && set +a
+
+import { writeFileSync } from 'node:fs';
+import { parseArgs } from './lib/seo-plan.mjs';
+import {
+  ADS_READINESS_ITEMS, getAdsReadiness, tickAdsReadiness, pinAdsCustomerId, getApiKey,
+} from './lib/webcore.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+
+const DOMAIN = args.domain && args.domain !== true ? String(args.domain) : null;
+if (!DOMAIN) {
+  console.error('❌ --domain <domain> is required (the exact registered domain).');
+  process.exit(1);
+}
+if (/\.vercel\.app$/.test(DOMAIN)) {
+  console.error(`⚠️  "${DOMAIN}" is a deploy host. Most fleet sites are registered on their`);
+  console.error('   paid domain — writing against the wrong key returns 2xx and orphans the row.');
+  console.error('   Verify first: curl -s "https://webcore.utopiaai.my/api/public/phone-numbers?website=<candidate>"');
+}
+
+const API_KEY = getApiKey();
+if (!API_KEY) {
+  console.error('❌ WEBCORE_API_KEY is not set (scope `ads:write`).');
+  console.error('   set -a && . ../../.env.local && set +a    # server-only; never commit it');
+  process.exit(1);
+}
+
+/** Accept the short names the runbook uses, plus the canonical ids. */
+const ALIASES = {
+  signals: 'google_signals',
+  google_signals: 'google_signals',
+  counting: 'conversion_counting',
+  conversion_counting: 'conversion_counting',
+  metrics: 'ga4_metrics_import',
+  import: 'ga4_metrics_import',
+  ga4_metrics_import: 'ga4_metrics_import',
+};
+
+function resolveItems(raw) {
+  const list = String(raw).split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (list.includes('all')) return [...ADS_READINESS_ITEMS];
+  return list.map((name) => {
+    const id = ALIASES[name];
+    if (!id) {
+      console.error(`❌ unknown item "${name}" — use: signals | counting | metrics | all`);
+      process.exit(1);
+    }
+    return id;
+  });
+}
+
+const LABELS = {
+  google_signals: 'GA4 → Google Signals ON',
+  conversion_counting: 'Ads → conversion Count = "One"',
+  ga4_metrics_import: 'Ads → Data manager → GA4 metrics import',
+};
+
+function printState(state) {
+  const r = state.readiness ?? {};
+  for (const item of ADS_READINESS_ITEMS) {
+    const on = r[item] === true;
+    const src = r[`${item}_source`];
+    console.log(`   ${on ? '✅' : '⬜'} ${item.padEnd(20)} ${LABELS[item]}${src ? `  (${src})` : ''}`);
+  }
+  console.log(`   ${state.ready ? '🎉 ready — all three confirmed' : '⏳ not ready yet'}`);
+
+  // A probe that cannot see the account reports why. Surfacing it stops the
+  // "it says false but the toggle IS on" round trip — the fix is --pin-customer-id.
+  const reasons = [
+    ['signals', state.signalsProbe?.reason],
+    ['counting', state.countingProbe?.reason],
+    ['ads link', state.adsLink?.reason],
+  ].filter(([, why]) => why);
+  if (reasons.length) {
+    console.log('   probe notes:');
+    for (const [what, why] of reasons) console.log(`     · ${what}: ${why}`);
+  }
+}
+
+// Resolve the item names BEFORE any network call — a typo should fail
+// instantly, not after a round trip that prints a state we then discard.
+const toTick = args.tick && args.tick !== true ? resolveItems(args.tick) : [];
+const toUntick = args.untick && args.untick !== true ? resolveItems(args.untick) : [];
+
+// ─── Read current state ───────────────────────────────────────────
+console.log(`\n📋 Ads readiness — ${DOMAIN}\n`);
+let state;
+try {
+  state = await getAdsReadiness(DOMAIN, API_KEY);
+} catch (err) {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+}
+console.log('   BEFORE:');
+printState(state);
+
+// ─── Pin the Ads customer id ──────────────────────────────────────
+if (args['pin-customer-id'] && args['pin-customer-id'] !== true) {
+  const customerId = String(args['pin-customer-id']);
+  console.log(`\n📌 Pinning Ads customer id ${customerId} …`);
+  try {
+    await pinAdsCustomerId(DOMAIN, customerId, API_KEY);
+    console.log('   ✅ pinned — the counting check will stop guessing.');
+  } catch (err) {
+    console.error(`   ❌ ${err.message}`);
+    process.exit(1);
+  }
+}
+
+// ─── Tick / untick ────────────────────────────────────────────────
+if (toTick.length) {
+  const current = state.readiness ?? {};
+  const pending = toTick.filter((i) => current[i] !== true);
+  const already = toTick.filter((i) => current[i] === true);
+  for (const i of already) console.log(`\n   ↷ ${i} already confirmed — skipping.`);
+
+  // Would this run leave all three done? That is the notification moment.
+  const after = new Set([...ADS_READINESS_ITEMS.filter((i) => current[i] === true), ...toTick]);
+  const completes = pending.length > 0 && ADS_READINESS_ITEMS.every((i) => after.has(i));
+
+  if (completes && !args.yes) {
+    console.error('\n⚠️  This would complete the card, which notifies the performance marketers ONCE.');
+    console.error('   Confirm every toggle is genuinely ON in the Google UI, then re-run with --yes.');
+    console.error('   Screenshots: https://websitebuilder.utopiaai.my/google (§04)');
+    process.exit(1);
+  }
+
+  for (const item of pending) {
+    console.log(`\n✅ Confirming ${item} — ${LABELS[item]}`);
+    try {
+      await tickAdsReadiness(DOMAIN, item, true, API_KEY);
+      console.log('   done.');
+    } catch (err) {
+      console.error(`   ❌ ${err.message}`);
+      process.exit(1);
+    }
+  }
+  if (completes) console.log('\n📣 Card complete — the performance marketers have been notified.');
+}
+
+for (const item of toUntick) {
+  console.log(`\n↩️  Un-confirming ${item} …`);
+  try {
+    await tickAdsReadiness(DOMAIN, item, false, API_KEY);
+    console.log('   done.');
+  } catch (err) {
+    console.error(`   ❌ ${err.message}`);
+    process.exit(1);
+  }
+}
+
+// ─── Final state ──────────────────────────────────────────────────
+if (toTick.length || toUntick.length || args['pin-customer-id']) {
+  state = await getAdsReadiness(DOMAIN, API_KEY);
+  console.log('\n   AFTER:');
+  printState(state);
+}
+
+if (args.json && args.json !== true) {
+  writeFileSync(String(args.json), JSON.stringify(state, null, 2));
+  console.log(`\n   wrote ${args.json}`);
+}
+
+if (!state.ready) {
+  const left = ADS_READINESS_ITEMS.filter((i) => state.readiness?.[i] !== true);
+  console.log(`\n⏳ Still owed: ${left.join(', ')}`);
+  console.log('   Flip the toggle in Google first, THEN tick it here.');
+}
+console.log('');

--- a/scripts/google-automation/lib/webcore.mjs
+++ b/scripts/google-automation/lib/webcore.mjs
@@ -90,3 +90,68 @@ export function pushKeywords(website, { rows, primary_keywords, secondary_keywor
 export function getApiKey() {
   return process.env.WEBCORE_API_KEY || null;
 }
+// ─── Ads readiness ────────────────────────────────────────────────
+//
+// Three Google settings gate a site running ads. Two are re-verified live by
+// webcore on every read; the third has no API that exposes it, so a human
+// confirms it once. Ticking an auto-verified item PINS it, so the live
+// re-check stops overriding the answer.
+//
+//   google_signals       GA4 → Google Signals ON          (auto-verified)
+//   conversion_counting  Ads → conversion Count = One     (auto-verified)
+//   ga4_metrics_import   Ads → Data manager → GA4 import  (manual only)
+
+/** The canonical item ids, in the order the Google UI presents them. */
+export const ADS_READINESS_ITEMS = [
+  'google_signals',
+  'conversion_counting',
+  'ga4_metrics_import',
+];
+
+/**
+ * Current readiness, with both automatic checks re-run live against Google.
+ * Needs `read`/`ads:write` scope — unlike the other `/api/public/*` reads.
+ * @returns {{ readiness: object, ready: boolean, adsLink: object,
+ *             signalsProbe: object, countingProbe: object }}
+ */
+export function getAdsReadiness(website, apiKey) {
+  if (!apiKey) throw new Error('WEBCORE_API_KEY is not set — the readiness endpoint needs it.');
+  return request(`/api/ads-readiness?website=${encodeURIComponent(website)}`, { apiKey });
+}
+
+/**
+ * Confirm (or un-confirm) one readiness item.
+ *
+ * ⚠️ Completing the LAST item notifies the performance marketers, once. Send
+ * `done: true` because the step is really done — never to tidy the card.
+ */
+export function tickAdsReadiness(website, item, done, apiKey) {
+  if (!apiKey) throw new Error('WEBCORE_API_KEY is not set — refusing to attempt a write.');
+  if (!ADS_READINESS_ITEMS.includes(item)) {
+    throw new Error(`unknown readiness item "${item}" — expected one of ${ADS_READINESS_ITEMS.join(', ')}`);
+  }
+  return request('/api/ads-readiness', {
+    method: 'PATCH', apiKey, body: { website, item, done },
+  });
+}
+
+/**
+ * Pin the Ads customer id when it cannot be resolved from the site's `AW-` tag
+ * (or when conversions live on a manager account), so the counting check stops
+ * guessing.
+ */
+export function pinAdsCustomerId(website, customerId, apiKey) {
+  if (!apiKey) throw new Error('WEBCORE_API_KEY is not set — refusing to attempt a write.');
+  return request('/api/ads-readiness', {
+    method: 'PUT', apiKey, body: { website, customerId },
+  });
+}
+
+/**
+ * What webcore actually sees for this site's Google setup — GA4, GTM, Ads and
+ * the readiness block. Every field is verified live on the call (Google API
+ * round trips included), so call it once after a setup run, never as a poll.
+ */
+export function getIntegrations(website, apiKey) {
+  return request(`/api/public/integrations?website=${encodeURIComponent(website)}`, { apiKey });
+}


### PR DESCRIPTION
Closes #66

Gloo finished Phase 5, handed the user three residual Google toggles, and
stopped. Those three toggles are exactly the three gates webcore's
ads-readiness card tracks — so a fully finished site kept reading
`ready: false`, and the performance marketers never learned it was ready.

## What's new

**`scripts/google-automation/ads-readiness.mjs`**

```bash
node ads-readiness.mjs --domain <d>                    # read state, writes nothing
node ads-readiness.mjs --domain <d> --tick all --yes   # confirm all three
node ads-readiness.mjs --domain <d> --tick metrics     # one item
node ads-readiness.mjs --domain <d> --untick counting  # undo a mistaken tick
node ads-readiness.mjs --domain <d> --pin-customer-id 123-456-7890
```

Short names (`signals` / `counting` / `metrics` / `all`) map to the canonical
item ids. Item names are resolved before any network call, so a typo fails
instantly instead of after a round trip.

**`lib/webcore.mjs`** — `getAdsReadiness`, `tickAdsReadiness`,
`pinAdsCustomerId`, `getIntegrations`, `ADS_READINESS_ITEMS`.

**Flow docs** now end at this step: bundle `SKILL.md`, the repo skill,
`agents/gloo.md` (new step 6 + report line + rule), `docs/full-website-setup.md`
(Phase 6 + end state), `MANUAL-STEPS.md`, and `CLAUDE.md`.

## Two guards

The card is a promise to someone else, so it is deliberately hard to close
carelessly:

1. **It runs only after the user confirms each toggle is really ON in the
   Google UI.** Ticking is a claim about Google's state, not about this script
   having run — every doc says so at the point of use.
2. **Completing the card notifies the performance marketers once**, so the
   completing tick refuses without an explicit `--yes` and exits 1.

Ticking an auto-verified item pins it against the live re-check. That is the
fix for the fleet sites whose counting probe reports `refused` /
`needs_reconsent` and reads `false` while the toggle is genuinely on — the
script surfaces those probe reasons instead of leaving you to guess.

## Verification

Run against live sites with the new key:

- `katilhospital.com.my` (ready) → all three ✅, `ready: true`, surfaces
  `counting: refused`
- `air-compressor.my` (1 of 3) → `--tick all` **without** `--yes` refused, exit
  1, and a follow-up read confirmed **nothing was written**
- `aircondpanasonic.my` (1 of 3) → read path lists what is still owed, exit 0
- `--tick bogus` → rejected before the network call, exit 1
- missing `WEBCORE_API_KEY` → clear error, exit 1

No readiness card was modified while testing. No credentials in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPAMBbuR1zUYVBuyAf5Yru