### PR TITLE
fix(cat-rumah): use the client's own job photos in the before/after slider

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
@@ -121,18 +121,19 @@ const ReasonIcon = ({ name }: { name: typeof reasonItems[number]['icon'] }) => {
 const faqIndexes = [1, 2, 3, 4, 5, 6, 7, 8]
 const reviewIndexes = [1, 2, 3, 4, 5, 6]
 
-// Before/After pairs — stable Unsplash photo IDs that resolve reliably on
-// the CDN. Each pair is the SAME room type (interior, exterior, accent
-// wall) shown pre- and post-paint so the slider reads as a real
-// transformation.
-const UNSPLASH = (id: string) => `https://images.unsplash.com/${id}?w=900&h=900&q=80&auto=format&fit=crop&crop=center`
+// Before/After pairs — the client's own watermarked job photos from
+// public/images/gallery. Each pair is a mid-paint or prep shot on the
+// "before" side and a finished handover shot on the "after" side. The
+// watermark sits at the identical spot in every file, so the two halves
+// meet cleanly at the divider instead of showing two clipped logos.
+const JOB = (name: string) => `/images/gallery/${name}.jpg`
 const beforeAfterPairs = [
-  // Interior — empty/raw room → freshly painted modern interior
-  { before: UNSPLASH('photo-1513694203232-719a280e022f'), after: UNSPLASH('photo-1505691938895-1758d7feb511'), captionKey: 'pair2Caption' },
-  // Exterior — weathered/older house → freshly painted exterior
-  { before: UNSPLASH('photo-1506744038136-46273834b3fb'), after: UNSPLASH('photo-1518780664697-55e3ad937233'), captionKey: 'pair1Caption' },
-  // Living/accent wall — older dim wall → fresh painted living room
-  { before: UNSPLASH('photo-1502672260266-1c1ef2d93688'), after: UNSPLASH('photo-1493809842364-78817add7ffb'), captionKey: 'pair3Caption' },
+  // Interior — beige walls mid-roller, drop sheets down → finished white room
+  { before: JOB('job-96'), after: JOB('job-88'), captionKey: 'pair2Caption' },
+  // Exterior — bare render being coated off the ladder → finished white facade
+  { before: JOB('job-84'), after: JOB('job-86'), captionKey: 'pair1Caption' },
+  // Ceiling + walls — pole roller on the ceiling → bright, evenly finished room
+  { before: JOB('job-92'), after: JOB('job-87'), captionKey: 'pair3Caption' },
 ] as const
 
 // Draggable before/after comparison slider. Pointer events handle both mouse
@@ -178,10 +179,13 @@ function BeforeAfterSlider({ before, after, beforeLabel, afterLabel }: { before:
       <img src={after} alt={afterLabel} className="absolute inset-0 w-full h-full object-cover" draggable={false} />
       <span className="absolute bottom-3 right-3 z-20 text-[10px] font-medium uppercase tracking-wider px-2.5 py-1 rounded-full" style={{ background: 'var(--brand-yellow)', color: 'var(--brand-ink)' }}>{afterLabel}</span>
 
-      {/* Before (top layer, clipped) */}
-      <div className="absolute inset-0 overflow-hidden" style={{ width: `${pos}%` }}>
+      {/* Before (top layer, clipped). clip-path keeps the image at full
+          container width, so it stays pixel-aligned with the after layer at
+          the divider — sizing the wrapper to `pos`% instead re-scaled the
+          image and knocked the two halves of the watermark out of register. */}
+      <div className="absolute inset-0" style={{ clipPath: `inset(0 ${100 - pos}% 0 0)` }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={before} alt={beforeLabel} className="absolute inset-0 h-full object-cover" style={{ width: ref.current?.clientWidth ? `${ref.current.clientWidth}px` : '100%' }} draggable={false} />
+        <img src={before} alt={beforeLabel} className="absolute inset-0 w-full h-full object-cover" draggable={false} />
         <span className="absolute bottom-3 left-3 text-[10px] font-medium uppercase tracking-wider px-2.5 py-1 rounded-full" style={{ background: 'var(--brand-ink)', color: '#fff' }}>{beforeLabel}</span>
       </div>
 

--- a/projects/cat-rumah-malaysia/messages/en.json
+++ b/projects/cat-rumah-malaysia/messages/en.json
@@ -164,9 +164,9 @@
       "subheading": "See how our customers' homes transform in just one day.",
       "before": "Before",
       "after": "After",
-      "pair1Caption": "Double-storey terrace exterior — pressure wash + two coats of Jotun weathershield.",
+      "pair1Caption": "Exterior walls — pressure wash, primer, then two coats of Jotun weathershield.",
       "pair2Caption": "Old living room → fresh clean white with neat finishing.",
-      "pair3Caption": "Dim, greasy kitchen → fresh wipe-clean colour.",
+      "pair3Caption": "Ceiling and walls rolled fresh — even coverage, no roller marks left behind.",
       "ctaButton": "See More",
       "dragHint": "Drag the divider to reveal the transformation"
     },

--- a/projects/cat-rumah-malaysia/messages/ms.json
+++ b/projects/cat-rumah-malaysia/messages/ms.json
@@ -164,9 +164,9 @@
       "subheading": "Lihat sendiri bagaimana rumah pelanggan kami berubah dalam 1 hari sahaja.",
       "before": "Sebelum",
       "after": "Selepas",
-      "pair1Caption": "Dinding luar terres dua tingkat — pressure-wash + dua lapisan weathershield Jotun.",
+      "pair1Caption": "Dinding luar — pressure-wash, primer, kemudian dua lapisan weathershield Jotun.",
       "pair2Caption": "Ruang tamu lama → cat baru putih bersih dengan kemasan rapi.",
-      "pair3Caption": "Dapur kotor dan kusam → warna baru tahan minyak.",
+      "pair3Caption": "Siling dan dinding dicat semula — lapisan sekata, tiada kesan roller.",
       "ctaButton": "Lihat Lagi",
       "dragHint": "Tarik garis tengah untuk lihat perubahan"
     },

--- a/projects/cat-rumah-malaysia/messages/zh.json
+++ b/projects/cat-rumah-malaysia/messages/zh.json
@@ -164,9 +164,9 @@
       "subheading": "看看客户的家如何在一天之内焕然一新。",
       "before": "之前",
       "after": "之后",
-      "pair1Caption": "双层排屋外墙 — 高压清洗 + 两层 Jotun 耐候漆。",
+      "pair1Caption": "外墙 — 高压清洗、底漆，再加两层 Jotun 耐候漆。",
       "pair2Caption": "陈旧客厅 → 洁白如新的细致完工。",
-      "pair3Caption": "昏暗油腻的厨房 → 清新易擦的新色彩。",
+      "pair3Caption": "天花与墙身重新滚涂 — 上色均匀，不留滚痕。",
       "ctaButton": "在 WhatsApp 查看更多",
       "dragHint": "拖动中线查看变化"
     },


### PR DESCRIPTION
Closes #68

The Before & After section on cat-rumah.my rendered six Unsplash stock photos. All three pairs now use `public/images/gallery/job-*.jpg` — the client's own watermarked job photos, already tracked in the repo.

| | before | after |
|---|---|---|
| interior | `job-96` beige wall mid-roller, drop sheets down | `job-88` finished white room, downlights |
| exterior | `job-84` bare render being coated off the ladder | `job-86` finished white facade |
| ceiling | `job-92` pole roller on the ceiling | `job-87` bright, evenly finished room |

Those three are the only finished-work shots in the set, so they also appear in the gallery grid below. With 13 photos total there is no way to avoid the overlap — worth a note for whenever the client sends more.

### Slider bug this surfaced

The before layer was a wrapper sized to `width: pos%` with the image inside reading `ref.current?.clientWidth`. That ref is null on the first render, so the width fell back to `100%` — of the *clipped* wrapper, not the container — and the image rendered at half scale until a drag forced a re-render. Invisible on stock photos; with the watermarked files it showed two clipped logos side by side at the divider. Replaced with `clip-path: inset(...)` on a full-size layer, so the image keeps container width and stays pixel-aligned. The watermark sits at identical coordinates in every file (x 392-727, y 814-1087 of 1200x1200), so the halves now meet as a single logo.

### Copy

`pair1Caption` claimed a double-storey terrace — job-84 is single-storey. `pair3Caption` described a greasy kitchen, and there is no kitchen photo in the set. Both rewritten in en/ms/zh; `pair2Caption` already matched.

### Verified

- `npm run build` passes
- served the production build on :3010 — zero `images.unsplash.com` references left in the rendered HTML
- screenshotted the section at 1440px and 390px: watermark halves align at the divider, captions match their images, cards centred on mobile
- `next.config.ts` keeps the `images.unsplash.com` remote pattern — blog post images come from the DB and may still use it

**Not deployed.** Merge does not publish; cat-rumah.my is still on `dpl_DyGyyE6wHqWuKdaMhDMGZK49qpW9` from 19 Aug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5VeVkNcrAQrTt11yxGDtC