### PR TITLE
feat(cat-rumah): rebuild the homepage and location pages on a colour system

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 import { locations as locationConfig } from '@/config/locations'
 import WhatsAppClickTracker from '@/components/tracking/WhatsAppClickTracker'
@@ -42,18 +42,28 @@ function waRedirect(locale: string, message?: string, location?: string) {
   return `/${locale}/redirect-whatsapp-1${qs ? `?${qs}` : ''}`
 }
 
-// 8 products — slug aligns with key in messages, image points to the brand
-// photo in /public/images/products.
-const productKeys: { key: string; slug: string; img: string; unit: 'sqft' | 'flat' }[] = [
-  { key: 'interior', slug: 'interior', img: '/images/products/interior-1.jpg', unit: 'sqft' },
-  { key: 'bedroom', slug: 'bedroom', img: '/images/products/bedroom-1.jpg', unit: 'sqft' },
-  { key: 'kitchen', slug: 'kitchen', img: '/images/products/kitchen-1.jpg', unit: 'sqft' },
-  { key: 'bathroom', slug: 'bathroom', img: '/images/products/bathroom-1.jpg', unit: 'sqft' },
-  { key: 'exterior', slug: 'exterior', img: '/images/products/exterior-1.jpg', unit: 'sqft' },
-  { key: 'weathershield', slug: 'weathershield', img: '/images/products/exterior-2.jpg', unit: 'sqft' },
-  { key: 'marble', slug: 'marble', img: '/images/products/marble-1.jpg', unit: 'flat' },
-  { key: 'texture', slug: 'texture', img: '/images/products/texture-1.jpg', unit: 'flat' },
-  { key: 'decor3d', slug: 'decor3d', img: '/images/products/decor3d-1.jpg', unit: 'flat' },
+// Nine services, each filed under one of three families. The family owns a
+// colour, and that colour is the only thing it owns — the key shown in the
+// hero has to keep meaning the same thing this far down the page, otherwise
+// it was decoration after all.
+type Family = 'dalam' | 'luar' | 'khas'
+
+const productKeys: { key: string; slug: string; img: string; unit: 'sqft' | 'flat'; family: Family }[] = [
+  { key: 'interior', slug: 'interior', img: '/images/products/interior-1.jpg', unit: 'sqft', family: 'dalam' },
+  { key: 'bedroom', slug: 'bedroom', img: '/images/products/bedroom-1.jpg', unit: 'sqft', family: 'dalam' },
+  { key: 'kitchen', slug: 'kitchen', img: '/images/products/kitchen-1.jpg', unit: 'sqft', family: 'dalam' },
+  { key: 'bathroom', slug: 'bathroom', img: '/images/products/bathroom-1.jpg', unit: 'sqft', family: 'dalam' },
+  { key: 'exterior', slug: 'exterior', img: '/images/products/exterior-1.jpg', unit: 'sqft', family: 'luar' },
+  { key: 'weathershield', slug: 'weathershield', img: '/images/products/exterior-2.jpg', unit: 'sqft', family: 'luar' },
+  { key: 'marble', slug: 'marble', img: '/images/products/marble-1.jpg', unit: 'flat', family: 'khas' },
+  { key: 'texture', slug: 'texture', img: '/images/products/texture-1.jpg', unit: 'flat', family: 'khas' },
+  { key: 'decor3d', slug: 'decor3d', img: '/images/products/decor3d-1.jpg', unit: 'flat', family: 'khas' },
+]
+
+const familyOrder: { id: Family; token: string; labelKey: string }[] = [
+  { id: 'dalam', token: 'var(--fam-dalam)', labelKey: 'famDalam' },
+  { id: 'luar', token: 'var(--fam-luar)', labelKey: 'famLuar' },
+  { id: 'khas', token: 'var(--fam-khas)', labelKey: 'famKhas' },
 ]
 
 // Drop the leading/trailing "from" word (Dari / From / 起) from a localized
@@ -201,7 +211,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
       {/* Inputs */}
       <div className="flex flex-col gap-4">
         <div>
-          <label htmlFor="calc-service" className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>
+          <label htmlFor="calc-service" className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>
             {t('serviceLabel')}
           </label>
           <select
@@ -225,7 +235,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
 
         {service.mode === 'sqft' ? (
           <div>
-            <label htmlFor="calc-area" className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>
+            <label htmlFor="calc-area" className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>
               {t('areaLabel')}
             </label>
             <input
@@ -252,7 +262,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
           </div>
         ) : (
           <div>
-            <span className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>
+            <span className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>
               {t('packageLabel')}
             </span>
             <div className="grid grid-cols-3 gap-2">
@@ -279,7 +289,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
       {/* Estimate output — blue dark panel per the palette rule (blue = bg) */}
       <div className="rounded-2xl p-6 flex flex-col justify-between" style={{ background: 'linear-gradient(135deg, var(--brand-blue) 0%, var(--brand-blue-deep) 100%)', color: '#fff' }}>
         <div>
-          <span className="block text-[10px] font-medium uppercase tracking-[0.18em]" style={{ color: 'var(--brand-yellow)' }}>{t('estimateLabel')}</span>
+          <span className="block text-[11px] font-semibold" style={{ color: 'var(--brand-yellow)' }}>{t('estimateLabel')}</span>
           <div className="mt-3 flex items-baseline gap-2">
             <span className="text-2xl font-bold" style={{ color: 'rgba(255,255,255,0.7)' }}>RM</span>
             <span className="text-5xl font-bold tabular-nums" style={{ color: '#fff', letterSpacing: '-0.02em' }}>{formatRM(estimate)}</span>
@@ -316,7 +326,7 @@ function StateCard({ stateName, cities, citiesLabel, locale }: { stateName: stri
     <article className="rounded-2xl p-5 flex flex-col" style={{ background: '#fff', border: '1px solid var(--line)', boxShadow: '0 4px 14px rgba(2, 61, 147, 0.04)', height: '100%' }}>
       <header className="flex items-baseline justify-between gap-2 pb-3 mb-3" style={{ borderBottom: '1px solid var(--line)' }}>
         <h4 className="text-sm font-bold m-0" style={{ color: 'var(--brand-ink)', letterSpacing: '-0.005em' }}>{stateName}</h4>
-        <span className="text-[10px] font-medium uppercase tracking-[0.14em]" style={{ color: 'var(--brand-pink)' }}>{cities.length} {citiesLabel}</span>
+        <span className="text-[11px] font-semibold" style={{ color: 'var(--brand-pink)' }}>{cities.length} {citiesLabel}</span>
       </header>
       <div className="flex flex-wrap gap-1.5">
         {cities.map((city) => (
@@ -334,23 +344,14 @@ function StateCard({ stateName, cities, citiesLabel, locale }: { stateName: stri
   )
 }
 
-function useFadeUp() {
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const obs = new IntersectionObserver(([e]) => {
-      if (e.isIntersecting) { el.classList.add('visible'); obs.disconnect() }
-    }, { threshold: 0.12 })
-    obs.observe(el)
-    return () => obs.disconnect()
-  }, [])
-  return ref
-}
-
-function FadeSection({ children, className = '', delay = 0 }: { children: React.ReactNode; className?: string; delay?: number }) {
-  const ref = useFadeUp()
-  return <div ref={ref} className={`fade-up ${className}`} style={{ transitionDelay: `${delay}ms` }}>{children}</div>
+// Was a scroll-triggered fade-and-slide-up on every section. That pattern is
+// the generic default and it parks content at opacity 0 until an observer
+// fires, so the first frame of the page is half empty. The wrapper stays
+// because the layout uses it as a grid/flex child; the motion is gone. The
+// only movement left on the page is the FOMO countdown, which is movement
+// that means something.
+function FadeSection({ children, className = '' }: { children: React.ReactNode; className?: string; delay?: number }) {
+  return <div className={className}>{children}</div>
 }
 
 type Props = { phoneNumber: string }
@@ -394,109 +395,62 @@ export default function HomePageClient({ phoneNumber }: Props) {
 
   return (
     <main>
-      {/* PRODUCTS */}
-      <section id="products" className="py-16 px-6" style={{ background: 'var(--brand-cream)' }} aria-labelledby="products-heading">
+      {/* SERVICES — grouped into the three colour families rather than nine
+          interchangeable cards. The family band is the only decoration on a
+          tile, and it is carrying information. */}
+      <section id="products" className="py-16 px-6" style={{ background: 'var(--paper-2)' }} aria-labelledby="products-heading">
         <div className="max-w-6xl mx-auto">
-          <FadeSection>
-            <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('products.tag')}</h5>
-              <h3 id="products-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('products.heading')}</h3>
-              <h5 className="text-sm font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{t('products.subheading')}</h5>
-            </div>
-          </FadeSection>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5" style={{ gridAutoRows: '1fr' }}>
-            {productKeys.map((p, i) => (
-              <ProductImpressionTracker key={p.key} slug={p.slug}>
-                <FadeSection delay={i * 40}>
-                  <div
-                    className="product-card bg-white rounded-2xl overflow-hidden flex flex-col"
-                    style={{
-                      border: '1px solid var(--line)',
-                      boxShadow: '0 6px 20px rgba(17, 17, 17, 0.04)',
-                      height: '100%',
-                    }}
-                  >
-                    {/* Photo */}
-                    <div className="relative w-full overflow-hidden" style={{ aspectRatio: '4 / 3', background: 'var(--brand-cream)' }}>
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={p.img} alt={t(`products.${p.key}.title`)} className="absolute inset-0 w-full h-full object-cover" loading="lazy" />
-                    </div>
-
-                    {/* Body — title + description are both height-locked to
-                        2 lines, so every card has identical total height
-                        without needing flex spacers. */}
-                    <div className="px-5 pt-5 pb-5 flex flex-col">
-                      <h3
-                        className="text-[17px] m-0"
-                        style={{
-                          color: 'var(--brand-ink)',
-                          fontWeight: 700,
-                          lineHeight: 1.3,
-                          letterSpacing: '-0.01em',
-                          minHeight: 'calc(1.3em * 2)',
-                          display: '-webkit-box',
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                        }}
-                      >
-                        {t(`products.${p.key}.title`)}
-                      </h3>
-
-                      <p
-                        className="m-0 mt-3"
-                        style={{
-                          color: 'var(--muted)',
-                          fontSize: 13.5,
-                          lineHeight: 1.6,
-                          // Lock to exactly 2 lines so every card in the row
-                          // has identical vertical spacing — shorter
-                          // descriptions don't leave ghost whitespace and
-                          // longer ones truncate cleanly with an ellipsis.
-                          height: 'calc(1.6em * 2)',
-                          display: '-webkit-box',
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                        }}
-                      >
-                        {t(`products.${p.key}.description`)}
-                      </p>
-
-                      {/* Footer: price (left) + CTA (right). No mt-auto —
-                          cards already match height naturally because every
-                          row above is height-locked. */}
-                      <div
-                        className="mt-5 pt-4 flex items-center justify-between gap-3"
-                        style={{ borderTop: '1px solid var(--line)' }}
-                      >
-                        <div className="flex flex-col leading-tight">
-                          <span className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'var(--muted)', fontWeight: 500 }}>
-                            {t('products.fromLabel')}
-                          </span>
-                          <span className="text-[20px]" style={{ color: 'var(--brand-pink)', fontWeight: 700, letterSpacing: '-0.01em' }}>
-                            {stripFromWord(t(p.unit === 'sqft' ? 'products.priceFromSqft' : 'products.priceFromFlat', { price: t(`products.${p.key}.price`) }))}
-                          </span>
-                        </div>
-                        <WhatsAppClickTracker
-                          phoneNumber={phoneNumber}
-                          href={WA_LINK}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={t('products.bookNow')}
-                          className="shrink-0 inline-flex items-center justify-center rounded-full"
-                          style={{ background: '#25D366', color: '#fff', width: 44, height: 44, boxShadow: '0 6px 16px rgba(37, 211, 102, 0.30)' }}
-                        >
-                          <WAIcon />
-                        </WhatsAppClickTracker>
-                      </div>
-                    </div>
-                  </div>
-                </FadeSection>
-              </ProductImpressionTracker>
-            ))}
+          <div className="mb-10 max-w-2xl mx-auto text-center">
+            <h3 id="products-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('products.heading')}</h3>
+            <p className="mt-3" style={{ color: 'var(--muted)', fontSize: 15.5 }}>{t('products.subheading')}</p>
           </div>
-          <h5 className="text-center text-xs font-normal mt-6 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{t('products.disclaimer')}</h5>
+
+          {familyOrder.map((fam) => {
+            const items = productKeys.filter((p) => p.family === fam.id)
+            return (
+              <div key={fam.id} className="fam-group" style={{ ['--fam' as string]: fam.token }}>
+                <header className="fam-head">
+                  <h4>{t(`products.${fam.labelKey}`)}</h4>
+                  <span>{items.length} {t('products.serviceUnit')}</span>
+                </header>
+
+                <div className="swatch-grid">
+                  {items.map((p) => (
+                    <ProductImpressionTracker key={p.key} slug={p.slug}>
+                      <article className="swatch">
+                        <div className="swatch-band" aria-hidden="true" />
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img className="swatch-shot" src={p.img} alt={t(`products.${p.key}.title`)} loading="lazy" />
+                        <div className="swatch-body">
+                          <h5>{t(`products.${p.key}.title`)}</h5>
+                          <p className="product-desc">{t(`products.${p.key}.description`)}</p>
+                          <div className="swatch-foot">
+                            <span className="swatch-price">
+                              <span>{t('products.fromLabel')}</span>
+                              <b>{stripFromWord(t(p.unit === 'sqft' ? 'products.priceFromSqft' : 'products.priceFromFlat', { price: t(`products.${p.key}.price`) }))}</b>
+                            </span>
+                            <WhatsAppClickTracker
+                              phoneNumber={phoneNumber}
+                              href={WA_LINK}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={t('products.bookNow')}
+                              className="shrink-0 inline-flex items-center justify-center rounded-full"
+                              style={{ background: '#25D366', color: '#fff', width: 42, height: 42 }}
+                            >
+                              <WAIcon />
+                            </WhatsAppClickTracker>
+                          </div>
+                        </div>
+                      </article>
+                    </ProductImpressionTracker>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+
+          <p className="mt-10 text-xs max-w-2xl mx-auto text-center" style={{ color: 'var(--muted)' }}>{t('products.disclaimer')}</p>
         </div>
       </section>
 
@@ -505,7 +459,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-5xl mx-auto">
           <FadeSection>
             <div className="text-center mb-8">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{tCalc('tag')}</h5>
               <h3 id="calc-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tCalc('heading')}</h3>
               <h5 className="text-sm font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tCalc('subheading')}</h5>
             </div>
@@ -521,7 +474,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('whyChoose.tag')}</h5>
               <h3 id="why-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('whyChoose.heading')}</h3>
             </div>
           </FadeSection>
@@ -552,7 +504,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('howItWorks.tag')}</h5>
               <h3 id="how-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('howItWorks.heading')}</h3>
             </div>
           </FadeSection>
@@ -634,7 +585,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('gallery.tag')}</h5>
               <h3 className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('gallery.heading')}</h3>
             </div>
           </FadeSection>
@@ -654,7 +604,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('faq.tag')}</h5>
               <h3 id="faq-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('faq.heading')}</h3>
             </div>
           </FadeSection>
@@ -673,7 +622,6 @@ export default function HomePageClient({ phoneNumber }: Props) {
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{t('locations.tag')}</h5>
               <h3 id="locations-heading" className="text-2xl md:text-3xl font-bold mb-2" style={{ color: 'var(--brand-ink)' }}>{t('locations.heading')}</h3>
               <h5 className="text-sm font-normal" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{t('locations.subheading')}</h5>
             </div>

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import WhatsAppClickTracker from '@/components/tracking/WhatsAppClickTracker'
 
@@ -89,7 +89,7 @@ const ReasonIcon = ({ name }: { name: typeof REASON_ITEMS[number]['icon'] }) => 
 const GALLERY_IMAGES = ['job-80','job-82','job-83','job-85','job-86','job-87','job-88','job-89','job-90','job-92','job-94','job-96'].map((n) => `/images/gallery/${n}.jpg`)
 
 const ChevronIcon = ({ open }: { open: boolean }) => (
-  <svg viewBox="0 0 20 20" className="w-5 h-5 shrink-0" style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.3s', color: '#142C50' }} fill="none" aria-hidden="true">
+  <svg viewBox="0 0 20 20" className="w-5 h-5 shrink-0" style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.3s', color: 'var(--brand-ink)' }} fill="none" aria-hidden="true">
     <path d="M5 8l5 5 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 )
@@ -97,35 +97,21 @@ const ChevronIcon = ({ open }: { open: boolean }) => (
 function FAQItem({ q, a }: { q: string; a: string }) {
   const [open, setOpen] = useState(false)
   return (
-    <div style={{ borderBottom: '1px solid rgba(20,28,48,0.10)' }}>
-      <button onClick={() => setOpen((o) => !o)} className="w-full flex items-center justify-between py-4 text-left cursor-pointer text-sm font-semibold" style={{ color: '#142C50' }} aria-expanded={open}>
+    <div style={{ borderBottom: '1px solid var(--line)' }}>
+      <button onClick={() => setOpen((o) => !o)} className="w-full flex items-center justify-between py-4 text-left cursor-pointer text-sm font-semibold" style={{ color: 'var(--brand-ink)' }} aria-expanded={open}>
         <span className="pr-4">{q}</span>
         <ChevronIcon open={open} />
       </button>
       <div style={{ maxHeight: open ? '300px' : '0px', overflow: 'hidden', transition: 'max-height 0.35s ease' }}>
-        <h5 className="pb-4 text-sm font-normal" style={{ color: '#5B6478', lineHeight: 1.6 }}>{a}</h5>
+        <h5 className="pb-4 text-sm font-normal" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{a}</h5>
       </div>
     </div>
   )
 }
 
-function useFadeUp() {
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const obs = new IntersectionObserver(([e]) => {
-      if (e.isIntersecting) { el.classList.add('visible'); obs.disconnect() }
-    }, { threshold: 0.12 })
-    obs.observe(el)
-    return () => obs.disconnect()
-  }, [])
-  return ref
-}
-
+// Motion stripped for the same reason as the homepage — see HomePageClient.
 function FadeSection({ children, className = '' }: { children: React.ReactNode; className?: string }) {
-  const ref = useFadeUp()
-  return <div ref={ref} className={`fade-up ${className}`}>{children}</div>
+  return <div className={className}>{children}</div>
 }
 
 function waRedirect(locale: string, message?: string, location?: string) {
@@ -182,27 +168,20 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
 
   return (
     <main>
-      {/* 3-POINT USP BAR */}
-      <section className="px-6 py-8 md:py-10" style={{ background: '#fff', borderBottom: '1px solid rgba(20,28,48,0.10)' }} aria-label="Why choose us">
+      {/* 3-POINT USP BAR — same single panel as the homepage. */}
+      <section className="px-6 py-8 md:py-10" style={{ background: 'var(--paper-1)', borderBottom: '1px solid var(--line)' }} aria-label={tUsp('usp1Title')}>
         <div className="max-w-6xl mx-auto">
-          <div
-            className="usp-panel rounded-2xl"
-            style={{ background: '#FAF7F2', border: '1px solid rgba(20,28,48,0.10)', padding: '20px', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '12px' }}
-          >
-            {uspItems.map((item) => (
-              <div
-                key={item.icon}
-                className="usp-cell flex flex-col md:flex-row md:items-center items-center text-center md:text-left gap-3 md:gap-4 p-3 md:p-4 rounded-xl"
-                style={{ background: '#fff', border: '1px solid rgba(20,28,48,0.06)' }}
-              >
-                <span className="shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl" style={{ background: 'rgba(20,28,48,0.06)', color: '#142C50' }} aria-hidden="true">
-                  {item.icon === 'clock' && (<svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>)}
-                  {item.icon === 'paint' && (<svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M19 7V3H5v8h14V7zM12 11v4M9 21h6v-6H9v6z"/></svg>)}
-                  {item.icon === 'shield' && (<svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/><path d="M9 12l2 2 4-4"/></svg>)}
-                </span>
+          <div className="usp-panel">
+            {uspItems.map((item, i) => (
+              <div key={item.icon} className="usp-cell">
+                <i
+                  className="usp-tick"
+                  style={{ background: ['var(--fam-dalam)', 'var(--fam-luar)', 'var(--fam-khas)'][i] }}
+                  aria-hidden="true"
+                />
                 <div>
-                  <h5 className="text-sm font-bold" style={{ color: '#142C50' }}>{item.title}</h5>
-                  <h5 className="text-xs font-normal mt-0.5" style={{ color: '#5B6478', lineHeight: 1.6 }}>{item.sub}</h5>
+                  <h5>{item.title}</h5>
+                  <h5 className="usp-sub">{item.sub}</h5>
                 </div>
               </div>
             ))}
@@ -211,16 +190,16 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
       </section>
 
       {/* SERVICES IN CITY */}
-      <section className="py-16 px-6" style={{ background: '#FAF7F2' }}>
+      <section className="py-16 px-6" style={{ background: 'var(--paper-2)' }}>
         <div className="max-w-6xl mx-auto">
           <FadeSection>
-            <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: '#142C50' }}>{t('services.heading', { city: cityName })}</h3>
+            <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: 'var(--brand-ink)' }}>{t('services.heading', { city: cityName })}</h3>
           </FadeSection>
           <div className="grid sm:grid-cols-2 gap-4 max-w-4xl mx-auto">
             {(['interior', 'exterior', 'ceiling', 'fence'] as const).map((k) => (
               <FadeSection key={k}>
-                <div className="bg-white p-5 rounded-xl" style={{ border: '1px solid rgba(20,28,48,0.10)' }}>
-                  <h5 className="text-sm font-normal" style={{ color: '#142C50', lineHeight: 1.6 }}>
+                <div className="bg-white p-5 rounded-xl" style={{ border: '1px solid var(--line)' }}>
+                  <h5 className="text-sm font-normal" style={{ color: 'var(--brand-ink)', lineHeight: 1.6 }}>
                     {t(`services.${k}`, { city: cityName })}
                   </h5>
                 </div>
@@ -235,7 +214,6 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{tHomeWhy('tag')}</h5>
               <h3 id="loc-why-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('why.heading', { city: cityName })}</h3>
             </div>
           </FadeSection>
@@ -262,7 +240,6 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{tHomeGallery('tag')}</h5>
               <h3 id="loc-gallery-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tHomeGallery('heading')}</h3>
             </div>
           </FadeSection>
@@ -282,7 +259,6 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         <div className="max-w-6xl mx-auto">
           <FadeSection>
             <div className="text-center mb-10">
-              <h5 className="text-[11px] font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{tHomeProducts('tag')}</h5>
               <h3 id="loc-products-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tHomeProducts('heading')}</h3>
               <h5 className="text-sm font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tHomeProducts('subheading')}</h5>
             </div>
@@ -304,7 +280,7 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
                     </p>
                     <div className="mt-5 pt-4 flex items-center justify-between gap-3" style={{ borderTop: '1px solid var(--line)' }}>
                       <div className="flex flex-col leading-tight">
-                        <span className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'var(--muted)', fontWeight: 500 }}>{tHomeProducts('fromLabel')}</span>
+                        <span className="text-[11px]" style={{ color: 'var(--muted)', fontWeight: 500 }}>{tHomeProducts('fromLabel')}</span>
                         <span className="text-[20px]" style={{ color: 'var(--brand-pink)', fontWeight: 700, letterSpacing: '-0.01em' }}>{stripFromWord(tHomeProducts(p.unit === 'sqft' ? 'priceFromSqft' : 'priceFromFlat', { price: tHomeProducts(`${p.key}.price`) }))}</span>
                       </div>
                       <WhatsAppClickTracker phoneNumber={phoneNumber} href={waLink} target="_blank" rel="noopener noreferrer" aria-label={tHomeProducts('bookNow')} className="shrink-0 inline-flex items-center justify-center rounded-full" style={{ background: '#25D366', color: '#fff', width: 44, height: 44, boxShadow: '0 6px 16px rgba(37, 211, 102, 0.30)' }}>
@@ -324,7 +300,6 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         <div className="max-w-5xl mx-auto">
           <FadeSection>
             <div className="text-center mb-8">
-              <h5 className="text-[11px] font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--brand-pink)' }}>{tCalc('tag')}</h5>
               <h3 id="loc-calc-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tCalc('heading')}</h3>
               <h5 className="text-sm font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tCalc('subheading')}</h5>
             </div>
@@ -333,7 +308,7 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
             <div className="rounded-2xl p-6 md:p-8 grid md:grid-cols-2 gap-6 md:gap-8" style={{ background: '#fff', border: '1px solid var(--line)', boxShadow: '0 20px 50px rgba(17, 17, 17, 0.06)' }}>
               <div className="flex flex-col gap-4">
                 <div>
-                  <label htmlFor="loc-calc-service" className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>{tCalc('serviceLabel')}</label>
+                  <label htmlFor="loc-calc-service" className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>{tCalc('serviceLabel')}</label>
                   <select id="loc-calc-service" value={calcServiceKey} onChange={(e) => setCalcServiceKey(e.target.value)} className="calc-select w-full px-4 py-3 rounded-xl text-sm font-semibold">
                     <optgroup label="Per sqft">
                       {sqftServices.map((s) => (
@@ -349,13 +324,13 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
                 </div>
                 {calcService.mode === 'sqft' ? (
                   <div>
-                    <label htmlFor="loc-calc-area" className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>{tCalc('areaLabel')}</label>
+                    <label htmlFor="loc-calc-area" className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>{tCalc('areaLabel')}</label>
                     <input id="loc-calc-area" type="number" min={50} step={50} value={calcArea} onChange={(e) => setCalcArea(Math.max(50, Number(e.target.value) || 0))} placeholder={tCalc('areaPlaceholder')} className="w-full px-4 py-3 rounded-xl text-sm font-semibold" style={{ background: 'var(--brand-cream)', border: '1px solid var(--line-strong)', color: 'var(--brand-ink)' }} />
                     <input type="range" min={50} max={5000} step={50} value={Math.min(calcArea, 5000)} onChange={(e) => setCalcArea(Number(e.target.value))} className="w-full mt-3" style={{ accentColor: 'var(--brand-yellow)' }} />
                   </div>
                 ) : (
                   <div>
-                    <span className="block text-xs font-bold uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>{tCalc('packageLabel')}</span>
+                    <span className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>{tCalc('packageLabel')}</span>
                     <div className="grid grid-cols-3 gap-2">
                       {(['single', 'medium', 'large'] as const).map((id) => (
                         <button key={id} type="button" onClick={() => setCalcPkg(id)} className="px-3 py-2.5 rounded-xl text-[11px] font-bold text-center" style={{ background: calcPkg === id ? 'var(--brand-blue)' : 'var(--brand-cream)', color: calcPkg === id ? '#fff' : 'var(--brand-ink)', border: `1px solid ${calcPkg === id ? 'var(--brand-blue)' : 'var(--line-strong)'}` }}>
@@ -439,10 +414,10 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
       </section>
 
       {/* FAQ */}
-      <section className="py-16 px-6" style={{ background: '#FAF7F2' }}>
+      <section className="py-16 px-6" style={{ background: 'var(--paper-2)' }}>
         <div className="max-w-6xl mx-auto">
           <FadeSection>
-            <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: '#142C50' }}>{t('faq.heading', { city: cityName })}</h3>
+            <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: 'var(--brand-ink)' }}>{t('faq.heading', { city: cityName })}</h3>
           </FadeSection>
           <FadeSection>
             <div className="max-w-3xl mx-auto">
@@ -458,12 +433,12 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         <section className="py-16 px-6" style={{ background: '#fff' }}>
           <div className="max-w-6xl mx-auto">
             <FadeSection>
-              <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: '#142C50' }}>{t('nearby.heading')}</h3>
+              <h3 className="text-2xl md:text-3xl font-bold text-center mb-10" style={{ color: 'var(--brand-ink)' }}>{t('nearby.heading')}</h3>
             </FadeSection>
             <FadeSection>
               <div className="flex flex-wrap justify-center gap-3">
                 {nearby.map((n) => (
-                  <a key={n.slug} href={`/${locale}/cat-rumah/${n.slug}`} className="px-5 py-3 rounded-xl text-sm font-semibold transition-opacity hover:opacity-80" style={{ background: 'rgba(20,28,48,0.06)', color: '#142C50', border: '1px solid rgba(20,28,48,0.10)' }}>
+                  <a key={n.slug} href={`/${locale}/cat-rumah/${n.slug}`} className="px-5 py-3 rounded-xl text-sm font-semibold transition-opacity hover:opacity-80" style={{ background: 'var(--line)', color: 'var(--brand-ink)', border: '1px solid var(--line)' }}>
                     {t('nearby.viewService', { city: n.name })}
                   </a>
                 ))}
@@ -476,7 +451,7 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
       {/* FINAL CTA */}
       <section
         className="relative py-20 px-6 text-center text-white overflow-hidden"
-        style={{ backgroundImage: 'linear-gradient(rgba(20,28,48,0.88), rgba(20,28,48,0.88)), url(/images/bg-cta.jpg)', backgroundSize: 'cover', backgroundPosition: 'center' }}
+        style={{ backgroundImage: 'linear-gradient(rgba(0, 31, 94, 0.88), rgba(0, 31, 94, 0.88)), url(/images/gallery/job-86.jpg)', backgroundSize: 'cover', backgroundPosition: 'center' }}
       >
         <div className="absolute inset-0 hero-bg" role="img" aria-label={t('cta.heading', { city: cityName })} style={{ pointerEvents: 'none' }} />
         <div className="relative max-w-3xl mx-auto">

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/page.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/page.tsx
@@ -60,6 +60,8 @@ export default async function LocationPage({ params }: { params: Promise<Params>
   const city = cityDisplay(location, locale)
   const tHero = await getTranslations({ locale, namespace: 'location.hero' })
   const tBread = await getTranslations({ locale, namespace: 'location.breadcrumb' })
+  const tHomeProducts = await getTranslations({ locale, namespace: 'home.products' })
+  const tHomeHeroLogo = await getTranslations({ locale, namespace: 'home.hero' })
   const tMeta = await getTranslations({ locale, namespace: 'location.meta' })
   const tRoot = await getTranslations({ locale })
   const imageAlt = tRoot('imageAlt')
@@ -90,40 +92,66 @@ export default async function LocationPage({ params }: { params: Promise<Params>
       <FomoBanner locale={locale as Locale} />
       <SiteHeader />
 
-      <section
-        className="relative overflow-hidden"
-        style={{
-          background:
-            'linear-gradient(135deg, rgba(20,28,48,0.92) 0%, rgba(20,28,48,0.88) 50%, rgba(20,28,48,0.94) 100%), url(/images/hero-bg.jpg) center/cover no-repeat',
-        }}
-      >
-        <div className="hero-bg" role="img" aria-label={imageAlt} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }} />
-        <div className="relative z-10 max-w-4xl mx-auto px-6 pt-14 md:pt-16 pb-12 text-center text-white">
-          <h6 className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/15 px-3.5 py-1 text-[11px] font-medium uppercase tracking-wider mb-4">
-            <span className="h-2 w-2 rounded-full" style={{ background: '#FFD23F' }} aria-hidden="true" />
-            {tHero('badge', { city })}
-          </h6>
-          <h1 className="font-bold mx-auto" style={{ fontSize: 'clamp(1.75rem, 4.4vw, 2.75rem)', letterSpacing: '-0.03em', lineHeight: 1.1 }}>
-            {tHero('headline', { city })}{' '}
-            <span style={{ color: '#FFD23F' }}>{tHero('headlineHighlight', { city })}</span>
-          </h1>
-          <h2 className="mt-4 text-sm md:text-base text-white/80 max-w-xl mx-auto font-normal" style={{ lineHeight: 1.6 }}>
-            {tHero('subheadline', { city })}
-          </h2>
-          <div className="mt-6 flex flex-col items-center gap-3">
-            <WhatsAppClickTracker phoneNumber={phone} href={waHref} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-6 py-3 rounded-xl text-sm font-semibold text-white" style={{ background: '#25D366' }}>
-              <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
-                <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z" />
-              </svg>
-              {tHero('cta', { city })}
-            </WhatsAppClickTracker>
-            <div className="flex flex-wrap items-center justify-center gap-2">
-              {tHero('ctaSubtext', { city }).split(' · ').map((part, i) => (
-                <span key={i} className="inline-flex items-center rounded-full bg-white/10 border border-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-white/70">
-                  {part}
-                </span>
-              ))}
+      {/* HERO — same treatment as the homepage: magnolia paper, left-aligned
+          type, the work photo in a card. Previously a navy gradient over
+          /images/hero-bg.jpg, a file that does not exist in public/, so the
+          photograph never loaded on any of the 165 location pages. */}
+      <section style={{ background: 'var(--paper-2)' }}>
+        <div className="max-w-6xl mx-auto px-6 pt-10 pb-14 md:pt-14 md:pb-16">
+          <div className="hero-grid">
+            <div className="hero-copy">
+              {/* Same reason as the homepage: the header chrome carries no logo. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="/images/brand/logo-dark.png"
+                alt={tHomeHeroLogo('logoAlt')}
+                className="hero-logo"
+                style={{ width: 150, height: 'auto' }}
+              />
+
+              <h1 className="hero-h1" style={{ color: 'var(--brand-ink)' }}>
+                {tHero('headline', { city })} {tHero('headlineHighlight', { city })}
+              </h1>
+
+              <h2 className="hero-sub" style={{ color: 'var(--muted)' }}>
+                {tHero('subheadline', { city })}
+              </h2>
+
+              <div className="hero-acts">
+                <WhatsAppClickTracker
+                  phoneNumber={phone}
+                  href={waHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-wa btn-lg"
+                >
+                  <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
+                    <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z" />
+                  </svg>
+                  {tHero('cta', { city })}
+                </WhatsAppClickTracker>
+              </div>
+
+              <p className="hero-support hero-fine">{tHero('ctaSubtext', { city })}</p>
+
+              <p className="hero-trust">
+                <span>{tHero('badge', { city })}</span>
+              </p>
+            </div>
+
+            <div className="hero-media">
+              <div
+                className="hero-shot"
+                role="img"
+                aria-label={imageAlt}
+                style={{ backgroundImage: 'url(/images/painters/painter-bg.jpg)' }}
+              />
+              <ul className="hero-key">
+                <li><i style={{ background: 'var(--fam-dalam)' }} aria-hidden="true" />{tHomeProducts('famDalam')}</li>
+                <li><i style={{ background: 'var(--fam-luar)' }} aria-hidden="true" />{tHomeProducts('famLuar')}</li>
+                <li><i style={{ background: 'var(--fam-khas)' }} aria-hidden="true" />{tHomeProducts('famKhas')}</li>
+              </ul>
             </div>
           </div>
         </div>

--- a/projects/cat-rumah-malaysia/app/[locale]/layout.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { seoAlternates } from '@/lib/seoAlternates'
-import { Inter, Noto_Sans_SC } from 'next/font/google'
+import { Archivo, Figtree, Noto_Sans_SC } from 'next/font/google'
 import { NextIntlClientProvider, hasLocale } from 'next-intl'
 import { getMessages, setRequestLocale, getTranslations } from 'next-intl/server'
 import { notFound } from 'next/navigation'
@@ -9,11 +9,22 @@ import { siteConfig } from '@/config/site'
 import '../globals.css'
 import { ogImages } from '@/lib/ogImage'
 
-const inter = Inter({
+// Two families, deliberately distinct. Archivo is a squared grotesque that
+// reads like hardware-shop signage and paint-tin labels; Figtree is the
+// humanist body face underneath it. CLAUDE.md forbids one family doing both
+// jobs, which the previous single-Inter setup was doing.
+const archivo = Archivo({
   subsets: ['latin', 'latin-ext'],
   display: 'swap',
-  variable: '--font-inter',
-  weight: ['400', '500', '600', '700', '800'],
+  variable: '--font-archivo',
+  weight: ['500', '600', '700', '800'],
+})
+
+const figtree = Figtree({
+  subsets: ['latin', 'latin-ext'],
+  display: 'swap',
+  variable: '--font-figtree',
+  weight: ['400', '500', '600', '700'],
 })
 
 const notoSC = Noto_Sans_SC({
@@ -67,7 +78,7 @@ export default async function LocaleLayout({ children, params }: Props) {
   return (
     <html
       lang={locale === 'zh' ? 'zh-Hans' : locale}
-      className={`${inter.variable} ${notoSC.variable}`}
+      className={`${archivo.variable} ${figtree.variable} ${notoSC.variable}`}
     >
       <head>
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/projects/cat-rumah-malaysia/app/[locale]/page.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/page.tsx
@@ -45,6 +45,7 @@ export default async function HomePage({ params }: Props) {
   const tUsp = await getTranslations({ locale, namespace: 'home.usp' })
   const tFaq = await getTranslations({ locale, namespace: 'home.faq' })
   const tBrands = await getTranslations({ locale, namespace: 'home.paintBrands' })
+  const tProducts = await getTranslations({ locale, namespace: 'home.products' })
   const tRoot = await getTranslations({ locale })
   const imageAlt = tRoot('imageAlt')
 
@@ -73,161 +74,103 @@ export default async function HomePage({ params }: Props) {
       <FomoBanner locale={locale as Locale} />
       <SiteHeader />
 
-      {/* HERO — dark section with a real painter-at-work image background,
-          the canonical role=img wrapper, and the page's single H1/H2 inside. */}
-      <section
-        className="relative overflow-hidden"
-        style={{
-          backgroundImage:
-            'linear-gradient(135deg, rgba(2, 61, 147, 0.90) 0%, rgba(2, 42, 102, 0.92) 50%, rgba(2, 30, 76, 0.96) 100%), url(/images/painters/painter-bg.jpg)',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-        }}
-      >
-        <div
-          className="hero-bg"
-          role="img"
-          aria-label={imageAlt}
-          style={{
-            position: 'absolute', inset: 0, pointerEvents: 'none',
-            backgroundImage: 'radial-gradient(circle at 80% 20%, rgba(255,210,63,0.22), transparent 55%), radial-gradient(circle at 15% 80%, rgba(233,30,99,0.18), transparent 55%)',
-          }}
-        />
-        <div className="relative z-10 max-w-5xl mx-auto px-6 pt-8 md:pt-10 pb-0 text-center text-white">
-          {/* Brand logo lives at the very top of the hero per design feedback */}
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/images/brand/logo-dark.png"
-            alt={tHero('logoAlt')}
-            className="mx-auto block"
-            style={{ width: 'min(180px, 50%)', height: 'auto' }}
-          />
-          {/* Trust line — plain uppercase text, no chip styling */}
-          <h6 className="mt-5 mb-4 text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: '#FFD23F' }}>
-            {tHero('badgeCertified')} · {tHero('badgeCities')}
-          </h6>
-          <h1
-            className="font-bold leading-[1.05] tracking-tight mx-auto"
-            style={{ fontSize: 'clamp(2rem, 5.2vw, 3.25rem)', letterSpacing: '-0.03em' }}
-          >
-            {tHero('headline')}{' '}
-            <span style={{ color: '#FFD23F' }}>{tHero('headlineHighlight')}</span>
-          </h1>
-          <h2 className="mt-4 text-sm md:text-base text-white/80 max-w-2xl mx-auto font-normal" style={{ lineHeight: 1.6 }}>
-            {tHero('subheadline')}
-          </h2>
+      {/* HERO — magnolia paper, left-aligned type, the work photo held in a
+          card. Deliberately neither dark nor centred: design-direction.md
+          audits four neighbouring fleet sites and marks both treatments HIGH
+          duplicate risk. The headline is one colour throughout — colouring a
+          single phrase inside it is the commonest generated-page tell. */}
+      <section style={{ background: 'var(--paper-2)' }}>
+        <div className="max-w-6xl mx-auto px-6 pt-10 pb-14 md:pt-14 md:pb-16">
+          <div className="hero-grid">
+            <div className="hero-copy">
+              {/* The header chrome carries no logo, so the mark lives here. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="/images/brand/logo-dark.png"
+                alt={tHero('logoAlt')}
+                className="hero-logo"
+                style={{ width: 150, height: 'auto' }}
+              />
 
-          {/* Promise tags — text only, no cutout PNGs */}
-          <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
-            {[tHero('tag1'), tHero('tag2'), tHero('tag3')].map((label) => (
-              <span
-                key={label}
-                className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-wider"
-                style={{ background: 'rgba(255,210,63,0.18)', border: '1px solid rgba(255,210,63,0.36)', color: '#FFD23F' }}
-              >
-                <span className="h-1.5 w-1.5 rounded-full" style={{ background: '#FFD23F' }} aria-hidden="true" />
-                {label}
-              </span>
-            ))}
-          </div>
+              <h1 className="hero-h1" style={{ color: 'var(--brand-ink)' }}>
+                {tHero('headline')} {tHero('headlineHighlight')}
+              </h1>
 
-          <div className="mt-6 flex flex-col items-center gap-3">
-            <WhatsAppClickTracker
-              phoneNumber={phone}
-              href={waHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-full text-base font-bold shadow-lg"
-              style={{ background: '#25D366', color: '#fff', boxShadow: '0 10px 30px rgba(37,211,102,0.35)' }}
-            >
-              <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
-                <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z" />
-              </svg>
-              {tHero('cta')}
-            </WhatsAppClickTracker>
-            <span className="text-[11px] font-medium text-white/65">
-              {tHero('ctaSubtext')}
-            </span>
-          </div>
+              <h2 className="hero-sub" style={{ color: 'var(--muted)' }}>
+                {tHero('subheadline')}
+              </h2>
 
-          {/* Painter photo with a rotated yellow "same-day" stamp */}
-          <div className="relative mt-10 mx-auto" style={{ maxWidth: 480 }}>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/images/painters/painter-roller.png"
-              alt={tHero('heroAlt')}
-              className="mx-auto block"
-              style={{ width: 'min(380px, 78%)', filter: 'drop-shadow(0 18px 38px rgba(0,0,0,0.45))' }}
-            />
-            <div
-              aria-hidden="false"
-              className="hero-stamp absolute"
-              style={{
-                top: '12%',
-                right: '4%',
-                width: 'clamp(110px, 22vw, 150px)',
-                height: 'clamp(110px, 22vw, 150px)',
-                transform: 'rotate(-12deg)',
-                background: '#FFD23F',
-                borderRadius: '50%',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: '#1F2A6B',
-                textAlign: 'center',
-                lineHeight: 1.05,
-                padding: 14,
-                boxShadow: '0 12px 30px rgba(0,0,0,0.35), inset 0 0 0 4px rgba(31,42,107,0.10)',
-                border: '3px dashed rgba(31,42,107,0.35)',
-                fontWeight: 900,
-                letterSpacing: '0.04em',
-                textTransform: 'uppercase',
-              }}
-            >
-              <span style={{ fontSize: 'clamp(11px, 2.4vw, 13px)', opacity: 0.85 }}>{tHero('stampSmall')}</span>
-              <span style={{ fontSize: 'clamp(15px, 3.2vw, 19px)', marginTop: 2 }}>{tHero('stampBig')}</span>
+              <div className="hero-acts">
+                <WhatsAppClickTracker
+                  phoneNumber={phone}
+                  href={waHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-wa btn-lg"
+                >
+                  <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
+                    <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z" />
+                  </svg>
+                  {tHero('cta')}
+                </WhatsAppClickTracker>
+
+                <span className="hero-price">
+                  <span className="hero-price-label">{tProducts('fromLabel')}</span>
+                  <b>{tProducts('priceFromSqft', { price: '3.50' }).replace(/^Dari\s+|^From\s+/i, '')}</b>
+                </span>
+              </div>
+
+              <p className="hero-support hero-fine">{tHero('ctaSubtext')}</p>
+
+              <p className="hero-trust">
+                <span>{tHero('badgeCertified')}</span>
+                <span className="hero-trust-rule" aria-hidden="true" />
+                <span>{tHero('badgeCities')}</span>
+              </p>
+            </div>
+
+            <div className="hero-media">
+              {/* CSS background rather than an <img> so the announced element
+                  is the one the fleet convention expects: role=img + label. */}
+              <div
+                className="hero-shot"
+                role="img"
+                aria-label={imageAlt}
+                style={{ backgroundImage: 'url(/images/painters/painter-bg.jpg)' }}
+              />
+              {/* The colour key. Every service on this page is filed under one
+                  of these three, and the same colour marks it wherever it
+                  appears — so the key is read once and reused. */}
+              <ul className="hero-key">
+                <li><i style={{ background: 'var(--fam-dalam)' }} aria-hidden="true" />{tProducts('famDalam')}</li>
+                <li><i style={{ background: 'var(--fam-luar)' }} aria-hidden="true" />{tProducts('famLuar')}</li>
+                <li><i style={{ background: 'var(--fam-khas)' }} aria-hidden="true" />{tProducts('famKhas')}</li>
+              </ul>
             </div>
           </div>
         </div>
       </section>
 
-      {/* 3-POINT USP BAR — brand PNG icons inside a single .usp-panel container */}
+      {/* 3-POINT USP BAR — one panel, three cells, divided by rules rather
+          than by giving each cell its own card fill and border. */}
       <section
         className="px-6 py-10 md:py-12"
-        style={{ background: '#fff', borderBottom: '1px solid var(--line)' }}
-        aria-label="Why choose us"
+        style={{ background: 'var(--paper-1)', borderBottom: '1px solid var(--line)' }}
+        aria-label={tUsp('usp1Title')}
       >
         <div className="max-w-6xl mx-auto">
-          <div
-            className="usp-panel rounded-2xl"
-            style={{
-              background: 'var(--brand-cream)',
-              border: '1px solid var(--line)',
-              padding: '20px',
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-              gap: '14px',
-            }}
-          >
-            {uspItems.map((item) => (
-              <div
-                key={item.icon}
-                className="usp-cell flex flex-col md:flex-row md:items-center items-center text-center md:text-left gap-3 md:gap-4 p-4 rounded-xl"
-                style={{ background: '#fff', border: '1px solid var(--line)' }}
-              >
-                <span
-                  className="shrink-0 inline-flex items-center justify-center"
-                  style={{ width: 56, height: 56 }}
+          <div className="usp-panel">
+            {uspItems.map((item, i) => (
+              <div key={item.icon} className="usp-cell">
+                <i
+                  className="usp-tick"
+                  style={{ background: [ 'var(--fam-dalam)', 'var(--fam-luar)', 'var(--fam-khas)' ][i] }}
                   aria-hidden="true"
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={`/images/usp/${item.icon}.png`} alt={item.title} style={{ width: 56, height: 56, objectFit: 'contain' }} />
-                </span>
+                />
                 <div>
-                  <h5 className="text-sm font-bold" style={{ color: 'var(--brand-ink)' }}>{item.title}</h5>
-                  <h5 className="text-xs font-normal mt-0.5" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{item.sub}</h5>
+                  <h5>{item.title}</h5>
+                  <h5 className="usp-sub">{item.sub}</h5>
                 </div>
               </div>
             ))}
@@ -238,7 +181,6 @@ export default async function HomePage({ params }: Props) {
       {/* PAINT BRANDS STRIP */}
       <section className="px-6 py-10" style={{ background: '#fff', borderBottom: '1px solid var(--line)' }} aria-labelledby="brands-heading">
         <div className="max-w-6xl mx-auto text-center">
-          <h5 className="text-[11px] font-medium uppercase tracking-widest mb-2" style={{ color: 'var(--muted)' }}>{tBrands('tag')}</h5>
           <h3 id="brands-heading" className="text-lg md:text-xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tBrands('heading')}</h3>
           <h5 className="text-xs font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tBrands('subheading')}</h5>
           <div className="mt-6 flex flex-wrap items-center justify-center gap-x-8 gap-y-4">

--- a/projects/cat-rumah-malaysia/app/globals.css
+++ b/projects/cat-rumah-malaysia/app/globals.css
@@ -1,56 +1,96 @@
 @import "tailwindcss";
 
 :root {
-  /* Brand palette — Cat Rumah Express
-     Headings + body text on light surfaces use near-black; brand blue
-     (#023d93) is reserved for dark-section gradients, accent borders, and
-     the language-switcher active pill. Yellow is the primary visual
-     accent, pink is the secondary highlight, cream is the warm off-white
-     section background. */
-  --brand-ink:            #111111;
-  --brand-ink-deep:       #0a0a0a;
-  --brand-blue:           #023d93;
-  --brand-blue-deep:      #022a66;
-  --brand-yellow:         #FFD23F;
-  --brand-yellow-deep:    #F0B900;
-  --brand-pink:           #E91E63;
-  --brand-pink-soft:      #FCE7EE;
-  --brand-sky:            #4FC3F7;
-  --brand-sky-soft:       #E5F4FB;
-  --brand-green:          #7CB342;
-  --brand-cream:          #FFF8EA;
-  --brand-cream-deep:     #FEEFC8;
-  --brand-charcoal:       #111111;
+  /* ── Colour is a code, not decoration ──────────────────────────────────
+     Every hue below is lifted from the Cat Rumah Express logo, and each one
+     is given exactly one job. A reader who learns the key in the hero can
+     use it for the rest of the page — which is the point of a colour key on
+     a painting company's site.
 
-  --ink:                  #111111;
-  --muted:                #5F6470;
-  --line:                 rgba(17, 17, 17, 0.10);
-  --line-strong:          rgba(17, 17, 17, 0.18);
+       deep blue   every heading, and the ink of the page
+       pink        the Dalaman service family (interior walls, bedroom,
+                   kitchen, bathroom)
+       sky         the Luar family (exterior, weathershield)
+       green       the Khas family (marble, texture, 3D relief)
+       yellow      the "cepat" promise and urgency only — never decoration
+       WhatsApp    #25D366, the CTA affordance, nothing else
 
-  --brand-accent:         #FFD23F;
-  --brand-accent-deep:    #F0B900;
+     Papers are three real off-whites, which is the question the trade
+     actually argues about: white, magnolia, cool white.
+     ─────────────────────────────────────────────────────────────────── */
+
+  /* ink */
+  --brand-ink:            #002E8A;
+  --brand-ink-deep:       #001F5E;
+  --brand-blue:           #002E8A;
+  --brand-blue-deep:      #001F5E;
+  --brand-charcoal:       #1A2233;
+  --ink:                  #1A2233;
+  --ink-muted:            #55606E;
+  --muted:                #55606E;
+
+  /* service families */
+  /* --fam is re-pointed per service group inline; this is its fallback. */
+  --fam:                  #DB3E77;
+  --fam-dalam:            #DB3E77;
+  --fam-luar:             #1E96DC;
+  --fam-khas:             #6BAF23;
+  --brand-pink:           #DB3E77;
+  --brand-pink-soft:      #FBE7EE;
+  --brand-sky:            #1E96DC;
+  --brand-sky-soft:       #E4F2FB;
+  --brand-green:          #6BAF23;
+  --brand-green-soft:     #EDF5E2;
+
+  /* promise + urgency */
+  --brand-yellow:         #F5C518;
+  --brand-yellow-deep:    #DDAE06;
+  --brand-accent:         #F5C518;
+  --brand-accent-deep:    #DDAE06;
+
+  /* papers */
+  --paper-1:              #FFFFFF;
+  --paper-2:              #F7F4E8;
+  --paper-3:              #EEF1F4;
+  --brand-cream:          #F7F4E8;
+  --brand-cream-deep:     #F0EBD8;
+
+  --line:                 rgba(0, 46, 138, 0.12);
+  --line-strong:          rgba(0, 46, 138, 0.22);
 
   --wa-green:             #25D366;
-  --wa-green-dark:        #1EAD53;
+  --wa-green-dark:        #1EBE57;
 
   --gut:                  20px;
   --dur:                  0.18s;
   --ease-out:             cubic-bezier(0.22, 1, 0.36, 1);
-  --font:                 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif;
+
+  /* Archivo carries every heading, Figtree the body. --font stays defined
+     because older rules in this file still reference it. */
+  --font-display:         var(--font-archivo), 'Archivo', system-ui, sans-serif;
+  --font-heading:         var(--font-archivo), 'Archivo', system-ui, sans-serif;
+  --font-body:            var(--font-figtree), 'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif;
+  --font:                 var(--font-figtree), 'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans SC', sans-serif;
 }
 
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
 
 body {
-  font-family: var(--font);
+  font-family: var(--font-body);
   color: var(--ink);
-  background: #ffffff;
+  background: var(--paper-1);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  line-height: 1.6;
+  line-height: 1.4;
   margin: 0;
 }
+
+/* CLAUDE.md text-spacing defaults: tight for display type, comfortable for
+   reading. Set here so every component inherits them. */
+h1, h2, h3, h4, h5, h6 { font-family: var(--font-display); line-height: 1.2; }
+p, li, blockquote,
+.blog-content p, .blog-content li, .blog-content blockquote { line-height: 1.4; }
 
 /* Heading weight scale:
    - h1: 700 (bold) — main page title
@@ -73,8 +113,8 @@ a { color: inherit; text-decoration: none; }
    ──────────────────────────────────────────────────────────── */
 .btn {
   display: inline-flex; align-items: center; gap: 8px;
-  padding: 12px 18px;
-  border-radius: 12px;
+  padding: 12px 20px;
+  border-radius: 999px;
   font-weight: 700; font-size: 14px;
   cursor: pointer;
   transition: transform var(--dur) var(--ease-out), background var(--dur) var(--ease-out), opacity var(--dur) var(--ease-out);
@@ -158,7 +198,28 @@ a { color: inherit; text-decoration: none; }
 /* ────────────────────────────────────────────────────────────
    USP panel (single container, three cells — checklist rule)
    ──────────────────────────────────────────────────────────── */
-.usp-panel { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.usp-panel {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background: var(--paper-1);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.usp-cell {
+  display: flex; gap: 12px; align-items: flex-start;
+  padding: 18px 22px;
+  border-right: 1px solid var(--line);
+}
+.usp-cell:last-child { border-right: 0; }
+.usp-tick { width: 4px; align-self: stretch; border-radius: 2px; flex: none; }
+.usp-cell h5 { font-size: 15px; font-weight: 700; color: var(--brand-ink); margin: 0 0 3px; }
+.usp-cell h5.usp-sub { font-size: 13px; font-weight: 400; color: var(--muted); margin: 0; line-height: 1.4; }
+@media (max-width: 860px) {
+  .usp-panel { grid-template-columns: 1fr; }
+  .usp-cell { border-right: 0; border-bottom: 1px solid var(--line); }
+  .usp-cell:last-child { border-bottom: 0; }
+}
 .usp-cell { display: flex; align-items: center; }
 
 /* ────────────────────────────────────────────────────────────
@@ -286,3 +347,103 @@ a { color: inherit; text-decoration: none; }
 }
 .utopia-credit:hover { transform: translateY(-1px); opacity: 0.85; }
 .utopia-credit__mark { flex: none; }
+
+
+/* ────────────────────────────────────────────────────────────
+   Hero — "Kad Warna"
+   Left-aligned on desktop; centred on mobile, which is the
+   primary viewport for this business.
+   ──────────────────────────────────────────────────────────── */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 52px;
+  align-items: center;
+}
+.hero-logo { display: block; margin-bottom: 22px; }
+.hero-h1 {
+  font-size: clamp(34px, 4.1vw, 52px);
+  font-weight: 800;
+  letter-spacing: -0.028em;
+  max-width: 13ch;
+  margin: 0;
+}
+.hero-sub {
+  font-family: var(--font-body);
+  font-size: 17.5px;
+  font-weight: 400;
+  line-height: 1.4;
+  max-width: 34ch;
+  margin: 18px 0 0;
+}
+.hero-acts { display: flex; align-items: center; gap: 22px; margin-top: 28px; flex-wrap: wrap; }
+.btn-lg { font-size: 15px; padding: 15px 24px; }
+.hero-price { display: block; font-weight: 700; color: var(--brand-ink); line-height: 1.2; }
+.hero-price-label { display: block; font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--muted); }
+.hero-price b { font-family: var(--font-display); font-size: 22px; font-weight: 800; color: var(--fam-dalam); }
+.hero-fine { margin: 14px 0 0; font-size: 13px; color: var(--muted); }
+.hero-trust {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  margin: 18px 0 0; font-size: 13px; color: var(--muted);
+}
+.hero-trust-rule { width: 1px; height: 13px; background: var(--line-strong); display: block; }
+
+.hero-shot {
+  aspect-ratio: 4 / 3;
+  max-width: 100%;
+  border-radius: 20px;
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 26px 50px -22px rgba(0, 46, 138, 0.42), 0 6px 14px -8px rgba(0, 46, 138, 0.16);
+}
+.hero-key {
+  display: flex; gap: 18px; flex-wrap: wrap;
+  margin: 16px 0 0; padding: 0; list-style: none;
+}
+.hero-key li {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12.5px; font-weight: 600; color: var(--brand-ink);
+}
+.hero-key i { width: 11px; height: 11px; border-radius: 3px; flex: none; display: block; }
+
+@media (max-width: 860px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 26px; text-align: center; }
+  .hero-logo { margin-left: auto; margin-right: auto; }
+  .hero-h1, .hero-sub { margin-left: auto; margin-right: auto; }
+  .hero-acts { flex-direction: column; align-items: center; gap: 16px; }
+  .hero-trust, .hero-key { justify-content: center; }
+}
+
+/* ────────────────────────────────────────────────────────────
+   Service swatch grid — nine services in three colour families.
+   The family colour is the tile's own band, so the colour key
+   learned in the hero keeps working down the page.
+   ──────────────────────────────────────────────────────────── */
+.fam-group + .fam-group { margin-top: 40px; }
+.fam-head {
+  display: flex; align-items: baseline; gap: 12px;
+  padding-bottom: 12px; margin-bottom: 18px;
+  border-bottom: 2px solid var(--fam);
+}
+.fam-head h4 { font-size: 19px; font-weight: 700; color: var(--brand-ink); margin: 0; }
+.fam-head span { font-family: var(--font-body); font-size: 13px; color: var(--muted); }
+.swatch-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(248px, 1fr)); gap: 18px; }
+.swatch {
+  display: flex; flex-direction: column;
+  background: var(--paper-1);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.swatch-band { height: 6px; background: var(--fam); }
+.swatch-shot { aspect-ratio: 4 / 3; width: 100%; object-fit: cover; display: block; }
+.swatch-body { padding: 16px 18px 18px; display: flex; flex-direction: column; gap: 6px; flex: 1; }
+.swatch-body h5 { font-size: 16px; font-weight: 700; color: var(--brand-ink); margin: 0; }
+.swatch-body p { font-family: var(--font-body); font-size: 13.5px; color: var(--muted); margin: 0; }
+.swatch-foot {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  margin-top: auto; padding-top: 14px;
+}
+.swatch-price { display: block; line-height: 1.2; }
+.swatch-price span { display: block; font-family: var(--font-body); font-size: 11px; font-weight: 500; color: var(--muted); }
+.swatch-price b { font-family: var(--font-display); font-size: 19px; font-weight: 800; color: var(--fam); }

--- a/projects/cat-rumah-malaysia/design-direction.md
+++ b/projects/cat-rumah-malaysia/design-direction.md
@@ -1,3 +1,13 @@
+> **Status note (2026-09-10).** The site was never built to the "Fresh Coat"
+> spec below — the delivered homepage used a centred dark-blue gradient hero,
+> which is the treatment §2 of this document explicitly rejects. The site has
+> since been rebuilt to a different direction, **"Kad Warna"**: magnolia paper,
+> deep blue `#002E8A` as the ink for every heading, and the three logo colours
+> assigned one job each as a service-family code (pink Dalaman, sky Luar, green
+> Khas), with yellow reserved for the speed promise. Archivo/Figtree replace
+> Inter. §1 (the peer audit) and §2 (the duplicate-risk report) still hold and
+> still drove the rebuild; §4 onward describes a spec that was not built.
+
 # Cat Rumah Malaysia — Design Direction
 
 **Author:** Kagura (UI Design Specialist)

--- a/projects/cat-rumah-malaysia/messages/en.json
+++ b/projects/cat-rumah-malaysia/messages/en.json
@@ -138,7 +138,11 @@
       "fromLabel": "From",
       "priceFromSqft": "From RM {price}/sqft",
       "priceFromFlat": "From RM {price}",
-      "disclaimer": "Final pricing depends on site inspection and surface area. Pressure wash + crack filling already included."
+      "disclaimer": "Final pricing depends on site inspection and surface area. Pressure wash + crack filling already included.",
+      "famDalam": "Interior",
+      "famLuar": "Exterior",
+      "famKhas": "Specialty Finishes",
+      "serviceUnit": "services"
     },
     "calculator": {
       "tag": "PRICE CALCULATOR",

--- a/projects/cat-rumah-malaysia/messages/ms.json
+++ b/projects/cat-rumah-malaysia/messages/ms.json
@@ -138,7 +138,11 @@
       "fromLabel": "Dari",
       "priceFromSqft": "Dari RM {price}/sqft",
       "priceFromFlat": "Dari RM {price}",
-      "disclaimer": "Harga muktamad bergantung kepada lawatan tapak dan keluasan permukaan. Pressure-wash + pendempulan retak sudah termasuk dalam quote."
+      "disclaimer": "Harga muktamad bergantung kepada lawatan tapak dan keluasan permukaan. Pressure-wash + pendempulan retak sudah termasuk dalam quote.",
+      "famDalam": "Cat Dalaman",
+      "famLuar": "Cat Luar",
+      "famKhas": "Kemasan Khas",
+      "serviceUnit": "servis"
     },
     "calculator": {
       "tag": "KALKULATOR ANGGARAN",

--- a/projects/cat-rumah-malaysia/messages/zh.json
+++ b/projects/cat-rumah-malaysia/messages/zh.json
@@ -138,7 +138,11 @@
       "fromLabel": "起",
       "priceFromSqft": "RM {price}/sqft 起",
       "priceFromFlat": "RM {price} 起",
-      "disclaimer": "最终价格视乎现场检查与表面积。高压清洗与裂缝填补已含在内。"
+      "disclaimer": "最终价格视乎现场检查与表面积。高压清洗与裂缝填补已含在内。",
+      "famDalam": "室内",
+      "famLuar": "室外",
+      "famKhas": "特殊饰面",
+      "serviceUnit": "项服务"
     },
     "calculator": {
       "tag": "价格计算器",


### PR DESCRIPTION
Closes #74

Rebuilds cat-rumah.my's homepage and its 165 location pages on one visual system. Chrome is untouched — `SiteHeader`, `SiteFooter`, `ContactNumber`, the redirect page and the blog surfaces stay locked to the `water-tank-malaysia` reference.

### Colour is a code, not decoration

Every hue is lifted from the logo and given exactly one job:

| Token | Hex | Its only job |
|---|---|---|
| `--brand-ink` | `#002E8A` | every heading, and the ink of the page |
| `--fam-dalam` | `#DB3E77` | Dalaman services — interior, bedroom, kitchen, bathroom |
| `--fam-luar` | `#1E96DC` | Luar services — exterior, weathershield |
| `--fam-khas` | `#6BAF23` | Khas services — marble, texture, 3D relief |
| `--brand-yellow` | `#F5C518` | the speed promise and urgency |
| `--wa-green` | `#25D366` | the WhatsApp affordance |

The key is shown in the hero, and it still means the same thing in the services grid and on every location page. Grounds are three real off-whites instead of one flat fill.

### What changed

- **Type is a pair** — Archivo display + Figtree body, replacing Inter doing both jobs, which `CLAUDE.md` forbids. Verified in the browser: `h1` computes to Archivo, `body` to Figtree.
- **Hero** is left-aligned on magnolia paper with the work photo in a card, neither dark nor centred. Mobile leads with the copy, then the photo.
- **Nine services** are grouped under their three families with a colour band per tile, instead of nine interchangeable cards. Grid uses `auto-fill` so a 2-item family keeps the same tile size as a 4-item one.
- **Eight ALL-CAPS section eyebrows removed**; uppercase form labels are sentence case.
- **Motion removed.** The scroll fade was the generic default and parked each section at `opacity: 0` until an observer fired, so the page's first frame was half empty. The FOMO countdown is the only movement left.

### Two bugs this surfaced

1. **All 165 location pages rendered a gradient over a 404.** The hero referenced `/images/hero-bg.jpg` and the CTA band `/images/bg-cta.jpg`; neither file exists in `public/`. The hero now uses the same card treatment as the homepage, and the CTA band a gallery photo that exists.
2. **Location pages had their own palette in hardcoded hex** (`#142C50`, `#FAF7F2`, `#5B6478`, `rgba(20,28,48,…)`) rather than the shared tokens — which is why the two page types read as two different sites. 25 literals repointed at tokens.

`design-direction.md` gets a status note: its peer audit and duplicate-risk report still hold and drove this rebuild, but §4 onward specs a "Fresh Coat" direction that was never built and is not what this is.

### Verified

- `npm run build` passes
- served the production build: homepage and `/cat-rumah/kuala-lumpur` each render exactly one `h1` and one `h2`
- computed fonts checked in-browser, not assumed
- every `/images/*` path referenced in code resolves to a file that exists
- no undefined CSS variables (framework `--font-*`/`--tw-*` excluded, as the wizard does)
- `.usp-panel` present on both page types; `role="img"` paired with `aria-label`; `#25D366` intact; every `cta`/`bookNow` label =3 words in en and ms
- looked at both pages at 1440px and 390px

**Not deployed** — merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5VeVkNcrAQrTt11yxGDtC