### PR TITLE
chore(webcore): point our tooling and build docs at the new host

### DIFF
--- a/docs/product-pricing-build.md
+++ b/docs/product-pricing-build.md
@@ -203,7 +203,7 @@ Into `components/PageStyles.tsx`, inside its `<style>` block.
 
 ```bash
 # CREATE — prices[] goes in on POST
-curl -X POST https://webcore.utopiaai.my/api/public/products \
+curl -X POST https://webcore.utopiagroup.com.my/api/public/products \
   -H "x-api-key: $WEBCORE_API_KEY" -H "Content-Type: application/json" \
   -d '{
         "website": "<exact registered domain>",
@@ -217,12 +217,12 @@ curl -X POST https://webcore.utopiaai.my/api/public/products \
       }'
 
 # UPDATE — the id goes in the BODY, not the query string
-curl -X PATCH https://webcore.utopiaai.my/api/public/products \
+curl -X PATCH https://webcore.utopiagroup.com.my/api/public/products \
   -H "x-api-key: $WEBCORE_API_KEY" -H "Content-Type: application/json" \
   -d '{ "id": "<product-id>", "prices": [ … ] }'
 
 # VERIFY — the public GET is CDN-cached, so bust it
-curl -s "https://webcore.utopiaai.my/api/public/products?website=<domain>&type=all&_=$(date +%s)" \
+curl -s "https://webcore.utopiagroup.com.my/api/public/products?website=<domain>&type=all&_=$(date +%s)" \
   -H "Cache-Control: no-cache"
 
 # PURGE the site's own cache after any write

--- a/docs/site-footer-build.md
+++ b/docs/site-footer-build.md
@@ -423,7 +423,7 @@ interface PhoneRow {
 `phone_numbers?select=phone_number,whatsapp_text,percentage,label,location_slug,page_slug,is_display`
 
 // 3. and near the top of the file
-const WEBCORE_PUBLIC_BASE = 'https://webcore.utopiaai.my';
+const WEBCORE_PUBLIC_BASE = 'https://webcore.utopiagroup.com.my';
 ```
 
 ### Translation keys — every locale
@@ -493,7 +493,7 @@ Without one the footer falls back to `siteConfig.fallbackPhone` — which must a
 be the client's own number, never a shared operator line.
 
 ```bash
-curl -s "https://webcore.utopiaai.my/api/public/phone-numbers/display?website=<domain>&page=/"
+curl -s "https://webcore.utopiagroup.com.my/api/public/phone-numbers/display?website=<domain>&page=/"
 
 # {"phone_number":"6011...","source":"all"}          -> good
 # {"error":"No display phone number configured..."}  -> seed a row first

--- a/docs/webcore-api.md
+++ b/docs/webcore-api.md
@@ -11,13 +11,27 @@ and integrations. Every agent that puts content into a site goes through this.
 
 ## Auth & conventions
 
-- **Base URL**: `https://webcore.utopiaai.my` (`$WEBCORE_BASE_URL`)
+- **Base URL**: `https://webcore.utopiagroup.com.my` (`$WEBCORE_BASE_URL`)
 - **Header**: `X-API-Key: $WEBCORE_API_KEY` on every write. Server-only.
 - **Scopes on the current key**: `products:write`, `blog:write`, `phones:write`,
   `seo:write`, `integrations:write`, `read`, `sites:write`, `ads:write`.
 - **Reads** (`GET /api/public/*`) are CORS-open and need **no** key.
 - `website` must be the **exact registered domain**. Writes against an
   unregistered value orphan silently — they return 2xx and never appear.
+
+> **Host moved (2026-09-10).** The old `webcore.utopiaai.my` now 307s to
+> `webcore.utopiagroup.com.my` for the whole host, `/t.js` included, and the new host does not redirect
+> further. 307 preserves method and body and both `fetch()` and `curl -L` follow
+> it, so nothing breaks today — which is exactly why this is easy to miss.
+>
+> **The fleet still points at the old host.** 37 live sites under `projects/`
+> carry a `webcore.utopiaai.my/t.js` tag, 7 `lib/webcore.ts` files hardcode it as
+> `WEBCORE_PUBLIC_BASE`, and `utopia-wizard/lib/checklist.ts`'s `tracking-script`
+> check asserts the old host **by name**. Those move together or not at all —
+> changing the sites while the guardrail still names the old host fails every
+> site's check. Moving them also means 37 redeploys, so it needs a decision on
+> whether the old host is actually being retired. Until then they ride the
+> redirect. Do not migrate a site's tag piecemeal.
 
 ### The vercel.app trap
 

--- a/docs/whatsapp-routing-build.md
+++ b/docs/whatsapp-routing-build.md
@@ -316,10 +316,10 @@ Freezes one number for every page, ignores `leads_mode`, and skips click trackin
 
 ```bash
 # what the page will PRINT (deterministic)
-curl -s "https://webcore.utopiaai.my/api/public/phone-numbers/display?website=<domain>&page=/"
+curl -s "https://webcore.utopiagroup.com.my/api/public/phone-numbers/display?website=<domain>&page=/"
 
 # what a click will REACH (rotates — run it a few times)
-curl -s "https://webcore.utopiaai.my/api/public/phone-numbers/resolve?website=<domain>&page=/"
+curl -s "https://webcore.utopiagroup.com.my/api/public/phone-numbers/resolve?website=<domain>&page=/"
 
 # the site's own redirect, following to wa.me
 curl -sI "https://<domain>/ms/redirect-whatsapp-1" | head -20

--- a/scripts/google-automation/ads-readiness.mjs
+++ b/scripts/google-automation/ads-readiness.mjs
@@ -51,7 +51,7 @@ if (!DOMAIN) {
 if (/\.vercel\.app$/.test(DOMAIN)) {
   console.error(`⚠️  "${DOMAIN}" is a deploy host. Most fleet sites are registered on their`);
   console.error('   paid domain — writing against the wrong key returns 2xx and orphans the row.');
-  console.error('   Verify first: curl -s "https://webcore.utopiaai.my/api/public/phone-numbers?website=<candidate>"');
+  console.error('   Verify first: curl -s "https://webcore.utopiagroup.com.my/api/public/phone-numbers?website=<candidate>"');
 }
 
 const API_KEY = getApiKey();

--- a/scripts/google-automation/keyword-volume.mjs
+++ b/scripts/google-automation/keyword-volume.mjs
@@ -378,7 +378,7 @@ if (args.push) {
       // The public GET is CDN-cached for 300s — verifying without a cache-buster
       // returns the pre-write state and looks like the push silently failed.
       console.log(`   Verify (cache-busted — the plain URL is cached 300s):`);
-      console.log(`     curl -s "https://webcore.utopiaai.my/api/public/keywords?website=${WEBSITE}&_cb=$RANDOM"`);
+      console.log(`     curl -s "https://webcore.utopiagroup.com.my/api/public/keywords?website=${WEBSITE}&_cb=$RANDOM"`);
     }
   }
 }

--- a/scripts/google-automation/lib/webcore.mjs
+++ b/scripts/google-automation/lib/webcore.mjs
@@ -6,9 +6,9 @@
 //
 //   export WEBCORE_API_KEY=uwc_...
 //
-// Docs: https://webcore.utopiaai.my — "Webcore Token API" reference.
+// Docs: https://webcore.utopiagroup.com.my — "Webcore Token API" reference.
 
-const BASE = process.env.WEBCORE_BASE_URL ?? 'https://webcore.utopiaai.my';
+const BASE = process.env.WEBCORE_BASE_URL ?? 'https://webcore.utopiagroup.com.my';
 
 /** webcore stores keywords per language, and only understands `en` / `ms`. */
 export const WEBCORE_LANGUAGES = new Set(['en', 'ms']);


### PR DESCRIPTION
Closes #95

`webcore.utopiaai.my` now 307s to `webcore.utopiagroup.com.my` for the whole
host, `/t.js` included. The new host serves everything and does not redirect
further, so it is canonical.

Nothing is broken today — 307 preserves method and body, and both `fetch()` and
`curl -L` follow it. That is precisely the risk: the move is invisible, every
call pays an extra round trip, and the day the redirect goes away everything
fails at once.

## In scope — this repo's tooling and build docs

| File | What changed |
|---|---|
| `lib/webcore.mjs` | the `BASE` fallback + docs pointer |
| `keyword-volume.mjs`, `ads-readiness.mjs` | the verify hints they print |
| `webcore-api.md` | stated base URL + a note on the move |
| `whatsapp-routing-build.md`, `site-footer-build.md`, `product-pricing-build.md` | curl examples and the `WEBCORE_PUBLIC_BASE` constant new sites are built from |

## Deliberately NOT in scope — the fleet

- **37 live sites** under `projects/` carrying a `webcore.utopiaai.my/t.js` tag
- **7 `lib/webcore.ts`** files hardcoding it as `WEBCORE_PUBLIC_BASE`
- **`utopia-wizard/lib/checklist.ts`** — its `tracking-script` check asserts the
  old host **by name**

These are coupled. Change the sites while the guardrail still names the old host
and every site fails `tracking-script`; change the guardrail first and nothing
enforces the tag. Moving them also means **37 redeploys** to buy something the
redirect already provides, and nobody has yet confirmed whether the old host is
being retired or kept as a permanent alias.

So they ride the redirect for now, and `webcore-api.md` carries a note saying so
— a recorded decision rather than a half-finished migration. Happy to do the
fleet as its own campaign once someone confirms the old host's fate.

## Verification

- `ads-readiness.mjs` reaches the new host with **no redirect**, both via
  `WEBCORE_BASE_URL` and via the hardcoded fallback with the env var unset
- new host: valid key → 200, bogus key → 401, no key → 401 (still genuinely gated)
- no `webcore.utopiaai.my` left anywhere under `docs/` or `scripts/`
- markdown fences balanced in the edited docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPAMBbuR1zUYVBuyAf5Yru