### PR TITLE
fix(cat-rumah): quiet the calculator slider and match the area input to the select

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
@@ -246,8 +246,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
               value={area}
               onChange={(e) => setArea(Math.max(minArea, Number(e.target.value) || 0))}
               placeholder={t('areaPlaceholder')}
-              className="w-full px-4 py-3 rounded-xl text-sm font-semibold"
-              style={{ background: 'var(--brand-cream)', border: '1px solid var(--line-strong)', color: 'var(--brand-ink)' }}
+              className="calc-input w-full px-4 py-3 rounded-xl text-sm font-semibold"
             />
             <input
               type="range"
@@ -256,8 +255,9 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
               step={50}
               value={Math.min(area, 5000)}
               onChange={(e) => setArea(Number(e.target.value))}
-              className="w-full mt-3 accent-yellow-400"
-              style={{ accentColor: 'var(--brand-yellow)' }}
+              aria-label={t('areaLabel')}
+              className="calc-range"
+              style={{ ['--fill' as string]: `${Math.min(100, Math.max(0, ((Math.min(area, 5000) - minArea) / (5000 - minArea)) * 100))}%` }}
             />
           </div>
         ) : (

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
@@ -318,8 +318,8 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
                 {calcService.mode === 'sqft' ? (
                   <div>
                     <label htmlFor="loc-calc-area" className="block text-[13px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>{tCalc('areaLabel')}</label>
-                    <input id="loc-calc-area" type="number" min={50} step={50} value={calcArea} onChange={(e) => setCalcArea(Math.max(50, Number(e.target.value) || 0))} placeholder={tCalc('areaPlaceholder')} className="w-full px-4 py-3 rounded-xl text-sm font-semibold" style={{ background: 'var(--brand-cream)', border: '1px solid var(--line-strong)', color: 'var(--brand-ink)' }} />
-                    <input type="range" min={50} max={5000} step={50} value={Math.min(calcArea, 5000)} onChange={(e) => setCalcArea(Number(e.target.value))} className="w-full mt-3" style={{ accentColor: 'var(--brand-yellow)' }} />
+                    <input id="loc-calc-area" type="number" min={50} step={50} value={calcArea} onChange={(e) => setCalcArea(Math.max(50, Number(e.target.value) || 0))} placeholder={tCalc('areaPlaceholder')} className="calc-input w-full px-4 py-3 rounded-xl text-sm font-semibold" />
+                    <input type="range" min={50} max={5000} step={50} value={Math.min(calcArea, 5000)} onChange={(e) => setCalcArea(Number(e.target.value))} aria-label={tCalc('areaLabel')} className="calc-range" style={{ ['--fill' as string]: `${Math.min(100, Math.max(0, ((Math.min(calcArea, 5000) - 50) / (5000 - 50)) * 100))}%` }} />
                   </div>
                 ) : (
                   <div>

--- a/projects/cat-rumah-malaysia/app/globals.css
+++ b/projects/cat-rumah-malaysia/app/globals.css
@@ -195,6 +195,74 @@ a { color: inherit; text-decoration: none; }
 .calc-select option { background: #fff; color: var(--brand-ink); }
 
 /* ────────────────────────────────────────────────────────────
+   Calculator number input + area slider
+   Blue is the one accent in the clean redesign; yellow stays
+   reserved for urgency. The slider is drawn on the input itself:
+   a 20px hit area whose middle 4px is the track, with the filled
+   share coming from --fill, set inline from the current value.
+   ──────────────────────────────────────────────────────────── */
+.calc-input {
+  background: #fff;
+  border: 1.5px solid var(--line-strong);
+  color: var(--brand-ink);
+}
+.calc-input:hover { border-color: var(--brand-blue); }
+.calc-input:focus {
+  outline: none;
+  border-color: var(--brand-blue);
+  box-shadow: 0 0 0 4px rgba(0, 46, 138, 0.14);
+}
+
+.calc-range {
+  -webkit-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  height: 20px;
+  padding: 8px 0;
+  margin: 10px 0 0;
+  background: linear-gradient(to right, var(--brand-blue) 0 var(--fill, 0%), #E3E7EE var(--fill, 0%) 100%);
+  background-clip: content-box;
+  border-radius: 999px;
+  cursor: pointer;
+  outline: none;
+}
+/* Vendor pseudo-elements are written one per rule: an unknown one inside a
+   selector list invalidates the whole list in the other engine. */
+.calc-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--brand-blue);
+  box-shadow: 0 1px 2px rgba(0, 46, 138, 0.18), 0 4px 10px -2px rgba(0, 46, 138, 0.22);
+  transition: transform var(--dur) var(--ease-out);
+}
+.calc-range::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--brand-blue);
+  box-shadow: 0 1px 2px rgba(0, 46, 138, 0.18), 0 4px 10px -2px rgba(0, 46, 138, 0.22);
+  transition: transform var(--dur) var(--ease-out);
+}
+.calc-range::-moz-range-track { background: transparent; height: 4px; border: 0; }
+.calc-range::-moz-range-progress { background: transparent; }
+.calc-range:hover::-webkit-slider-thumb { transform: scale(1.08); }
+.calc-range:hover::-moz-range-thumb { transform: scale(1.08); }
+.calc-range:active::-webkit-slider-thumb { transform: scale(1.16); }
+.calc-range:active::-moz-range-thumb { transform: scale(1.16); }
+.calc-range:focus-visible::-webkit-slider-thumb { box-shadow: 0 0 0 4px rgba(0, 46, 138, 0.18); }
+.calc-range:focus-visible::-moz-range-thumb { box-shadow: 0 0 0 4px rgba(0, 46, 138, 0.18); }
+@media (prefers-reduced-motion: reduce) {
+  .calc-range::-webkit-slider-thumb { transition: none; }
+  .calc-range::-moz-range-thumb { transition: none; }
+}
+
+/* ────────────────────────────────────────────────────────────
    USP panel (single container, three cells — checklist rule)
    ──────────────────────────────────────────────────────────── */
 /* Pull the panel 24px left of the content edge so the cell padding lands the


### PR DESCRIPTION
Closes #97

The area slider was a native `<input type="range">` with `accentColor` set to the brand yellow. Given a light accent the browser draws the unfilled track in near-black, so it rendered as a thick yellow bar on a heavy charcoal one — the darkest element in its section, in a colour the palette reserves for urgency.

### Now

- **Slider** drawn on the input itself: a 20px hit area whose middle 4px is the track, filled in brand blue up to `--fill` (set inline from the value), white thumb on a blue ring
- **Number input** takes the same white ground, border and blue focus ring as the `<select>` beside it
- **States:** hover and active scale the thumb (transform only), keyboard focus adds a soft halo, `prefers-reduced-motion` drops the transition
- Vendor thumb pseudo-elements are one per rule — an unknown one in a selector list voids the whole list in the other engine
- Both range inputs gain an `aria-label` from the existing `areaLabel` key; they had none

Homepage and location pages both.

### Verified

Built and served from an isolated worktree off `origin/main` (`node_modules` cloned, not symlinked).

- `npm run build` → `✓ Compiled successfully`
- computed in the browser: fill `19.19%` at the default 1000 sqft, track gradient in `rgb(0, 46, 138)`, range height 20px, input background `rgb(255, 255, 255)`
- looked at the control at 1440px and 390px, with keyboard focus on, and on `/cat-rumah/ipoh`

**Not deployed** — merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQT9gkRF4s7Tfv7yH3yoQ1