### PR TITLE
Document the webcore photos shape and that PATCH replaces them

### DIFF
--- a/docs/webcore-api.md
+++ b/docs/webcore-api.md
@@ -97,7 +97,7 @@ straight in as `company_id`.
 GET    /api/public/products?website=<d>              # nested main+sub
 GET    /api/public/products?website=<d>&slug=<slug>  # single
 GET    /api/public/products?website=<d>&type=all     # flat
-POST   /api/public/products   { website, name, slug, description?, sale_price?, rental_price?, prices?, parent_id?, photos? }
+POST   /api/public/products   { website, name, slug, description?, sale_price?, rental_price?, prices?, parent_id?, photos?: [{ url }] }
 PATCH  /api/public/products?id=<id>   { ...fields }
 DELETE /api/public/products?id=<id>
 ```
@@ -111,6 +111,16 @@ For anything with more than one rate send `prices` instead of the single
   { "label": "Bulanan", "amount": 32000, "unit": "month" },
   { "label": "Deposit", "amount": 5000 }
 ]
+```
+
+`photos` is an array of `{ url }` objects — a bare string array is rejected with
+`400 photos[0].url is required`. `PATCH` accepts it too, and **replaces** the
+product's photos rather than appending, so send the full set you want to keep.
+That is how to change a live product's photos: DELETE + re-POST would give it a
+new id and orphan anything that referenced the old one.
+
+```jsonc
+"photos": [{ "url": "/images/fleet/motor.jpg" }]
 ```
 
 ## 3. Phone numbers — `phones:write`


### PR DESCRIPTION
`docs/webcore-api.md` listed `photos?` on `POST /api/public/products` only, with no shape — so it read as if photos could only be set at creation, which pushes toward DELETE + re-POST (new id, orphaned references).

This adds:
- the shape, `photos?: [{ url }]`, on the POST line
- a short note that a bare string array is rejected (`400 photos[0].url is required`), and that `PATCH` accepts `photos` and **replaces** the existing set rather than appending

**Verified** against `webcore.utopiagroup.com.my` on 2026-09-10 while updating revmove.my's catalogue: string array → 400; `[{url}]` → 200; readback showed the old photo gone and only the new one present.

The PATCH `?id=<id>` line is left unchanged — it returns 200 on the new host (it only failed on the old one).

Docs only; no build step involved.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeD8N7a6vxWjZtMi9zG3mZ