### PR TITLE
feat(cat-rumah): drive the services grid from webcore

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 import { locations as locationConfig } from '@/config/locations'
 import WhatsAppClickTracker from '@/components/tracking/WhatsAppClickTracker'
-import ProductImpressionTracker from '@/components/tracking/ProductImpressionTracker'
+import ServicesGrid from '@/components/ServicesGrid'
+import type { Product } from '@/lib/webcore'
 
 const WAIcon = () => (
   <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
@@ -42,33 +43,7 @@ function waRedirect(locale: string, message?: string, location?: string) {
   return `/${locale}/redirect-whatsapp-1${qs ? `?${qs}` : ''}`
 }
 
-// Nine services, each filed under one of three families. The family owns a
-// colour, and that colour is the only thing it owns — the key shown in the
-// hero has to keep meaning the same thing this far down the page, otherwise
-// it was decoration after all.
-type Family = 'dalam' | 'luar' | 'khas'
 
-const productKeys: { key: string; slug: string; img: string; unit: 'sqft' | 'flat'; family: Family }[] = [
-  { key: 'interior', slug: 'interior', img: '/images/products/interior-1.jpg', unit: 'sqft', family: 'dalam' },
-  { key: 'bedroom', slug: 'bedroom', img: '/images/products/bedroom-1.jpg', unit: 'sqft', family: 'dalam' },
-  { key: 'kitchen', slug: 'kitchen', img: '/images/products/kitchen-1.jpg', unit: 'sqft', family: 'dalam' },
-  { key: 'bathroom', slug: 'bathroom', img: '/images/products/bathroom-1.jpg', unit: 'sqft', family: 'dalam' },
-  { key: 'exterior', slug: 'exterior', img: '/images/products/exterior-1.jpg', unit: 'sqft', family: 'luar' },
-  { key: 'weathershield', slug: 'weathershield', img: '/images/products/exterior-2.jpg', unit: 'sqft', family: 'luar' },
-  { key: 'marble', slug: 'marble', img: '/images/products/marble-1.jpg', unit: 'flat', family: 'khas' },
-  { key: 'texture', slug: 'texture', img: '/images/products/texture-1.jpg', unit: 'flat', family: 'khas' },
-  { key: 'decor3d', slug: 'decor3d', img: '/images/products/decor3d-1.jpg', unit: 'flat', family: 'khas' },
-]
-
-const familyOrder: { id: Family; token: string; labelKey: string }[] = [
-  { id: 'dalam', token: 'var(--fam-dalam)', labelKey: 'famDalam' },
-  { id: 'luar', token: 'var(--fam-luar)', labelKey: 'famLuar' },
-  { id: 'khas', token: 'var(--fam-khas)', labelKey: 'famKhas' },
-]
-
-// Drop the leading/trailing "from" word (Dari / From / 起) from a localized
-// price line — the fromLabel above already shows it.
-const stripFromWord = (s: string) => s.replace(/^(?:Dari|From)\s+/i, '').replace(/\s*起$/, '')
 
 // Why-choose reasons — each has a matching SVG icon name.
 const reasonItems: { key: string; icon: 'paint' | 'bolt' | 'shield' | 'tag' | 'badge' | 'pin' }[] = [
@@ -354,9 +329,9 @@ function FadeSection({ children, className = '' }: { children: React.ReactNode; 
   return <div className={className}>{children}</div>
 }
 
-type Props = { phoneNumber: string }
+type Props = { phoneNumber: string; products: Product[] }
 
-export default function HomePageClient({ phoneNumber }: Props) {
+export default function HomePageClient({ phoneNumber, products }: Props) {
   const locale = useLocale()
   const t = useTranslations('home')
   const tCalc = useTranslations('home.calculator')
@@ -395,64 +370,7 @@ export default function HomePageClient({ phoneNumber }: Props) {
 
   return (
     <main>
-      {/* SERVICES — grouped into the three colour families rather than nine
-          interchangeable cards. The family band is the only decoration on a
-          tile, and it is carrying information. */}
-      <section id="products" className="py-16 px-6" style={{ background: 'var(--paper-2)' }} aria-labelledby="products-heading">
-        <div className="max-w-6xl mx-auto">
-          <div className="mb-10 max-w-2xl mx-auto text-center">
-            <h3 id="products-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('products.heading')}</h3>
-            <p className="mt-3" style={{ color: 'var(--muted)', fontSize: 15.5 }}>{t('products.subheading')}</p>
-          </div>
-
-          {familyOrder.map((fam) => {
-            const items = productKeys.filter((p) => p.family === fam.id)
-            return (
-              <div key={fam.id} className="fam-group" style={{ ['--fam' as string]: fam.token }}>
-                <header className="fam-head">
-                  <h4>{t(`products.${fam.labelKey}`)}</h4>
-                  <span>{items.length} {t('products.serviceUnit')}</span>
-                </header>
-
-                <div className="swatch-grid">
-                  {items.map((p) => (
-                    <ProductImpressionTracker key={p.key} slug={p.slug}>
-                      <article className="swatch">
-                        <div className="swatch-band" aria-hidden="true" />
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img className="swatch-shot" src={p.img} alt={t(`products.${p.key}.title`)} loading="lazy" />
-                        <div className="swatch-body">
-                          <h5>{t(`products.${p.key}.title`)}</h5>
-                          <p className="product-desc">{t(`products.${p.key}.description`)}</p>
-                          <div className="swatch-foot">
-                            <span className="swatch-price">
-                              <span>{t('products.fromLabel')}</span>
-                              <b>{stripFromWord(t(p.unit === 'sqft' ? 'products.priceFromSqft' : 'products.priceFromFlat', { price: t(`products.${p.key}.price`) }))}</b>
-                            </span>
-                            <WhatsAppClickTracker
-                              phoneNumber={phoneNumber}
-                              href={WA_LINK}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              aria-label={t('products.bookNow')}
-                              className="shrink-0 inline-flex items-center justify-center rounded-full"
-                              style={{ background: '#25D366', color: '#fff', width: 42, height: 42 }}
-                            >
-                              <WAIcon />
-                            </WhatsAppClickTracker>
-                          </div>
-                        </div>
-                      </article>
-                    </ProductImpressionTracker>
-                  ))}
-                </div>
-              </div>
-            )
-          })}
-
-          <p className="mt-10 text-xs max-w-2xl mx-auto text-center" style={{ color: 'var(--muted)' }}>{t('products.disclaimer')}</p>
-        </div>
-      </section>
+      <ServicesGrid products={products} phoneNumber={phoneNumber} waHref={WA_LINK} headingId="products-heading" />
 
       {/* CALCULATOR */}
       <section id="calculator" className="py-16 px-6" style={{ background: '#fff', borderTop: '1px solid var(--line)' }} aria-labelledby="calc-heading">

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import WhatsAppClickTracker from '@/components/tracking/WhatsAppClickTracker'
+import ServicesGrid from '@/components/ServicesGrid'
+import type { Product } from '@/lib/webcore'
 
 const WAIcon = () => (
   <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
@@ -26,23 +28,6 @@ const GoogleLogo = () => (
   </svg>
 )
 
-// Product list mirrors HomePageClient so the location page shows the same
-// 9-card services grid as the homepage.
-const PRODUCT_KEYS: { key: string; img: string; unit: 'sqft' | 'flat' }[] = [
-  { key: 'interior', img: '/images/products/interior-1.jpg', unit: 'sqft' },
-  { key: 'bedroom', img: '/images/products/bedroom-1.jpg', unit: 'sqft' },
-  { key: 'kitchen', img: '/images/products/kitchen-1.jpg', unit: 'sqft' },
-  { key: 'bathroom', img: '/images/products/bathroom-1.jpg', unit: 'sqft' },
-  { key: 'exterior', img: '/images/products/exterior-1.jpg', unit: 'sqft' },
-  { key: 'weathershield', img: '/images/products/exterior-2.jpg', unit: 'sqft' },
-  { key: 'marble', img: '/images/products/marble-1.jpg', unit: 'flat' },
-  { key: 'texture', img: '/images/products/texture-1.jpg', unit: 'flat' },
-  { key: 'decor3d', img: '/images/products/decor3d-1.jpg', unit: 'flat' },
-]
-
-// Drop the leading/trailing "from" word (Dari / From / 起) from a localized
-// price line — the fromLabel above already shows it.
-const stripFromWord = (s: string) => s.replace(/^(?:Dari|From)\s+/i, '').replace(/\s*起$/, '')
 
 // Calculator service rates — mirror catrumah.com.my (also mirrors homepage).
 type CalcMode = 'sqft' | 'package'
@@ -128,9 +113,10 @@ type Props = {
   cityName: string
   phoneNumber: string
   nearby: { slug: string; name: string }[]
+  products: Product[]
 }
 
-export default function LocationPageClient({ locale, locationSlug, cityName, phoneNumber, nearby }: Props) {
+export default function LocationPageClient({ locale, locationSlug, cityName, phoneNumber, nearby, products }: Props) {
   const t = useTranslations('location')
   const tHomeReviews = useTranslations('home.reviews')
   const tHomeProducts = useTranslations('home.products')
@@ -247,46 +233,7 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
         </div>
       </section>
 
-      {/* PRODUCTS — mirrors the homepage 9-card services grid */}
-      <section id="products" className="py-16 px-6" style={{ background: 'var(--brand-cream)' }} aria-labelledby="loc-products-heading">
-        <div className="max-w-6xl mx-auto">
-          <FadeSection>
-            <div className="text-center mb-10">
-              <h3 id="loc-products-heading" className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tHomeProducts('heading')}</h3>
-              <h5 className="text-sm font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tHomeProducts('subheading')}</h5>
-            </div>
-          </FadeSection>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5" style={{ gridAutoRows: '1fr' }}>
-            {PRODUCT_KEYS.map((p) => (
-              <FadeSection key={p.key}>
-                <div className="bg-white rounded-2xl overflow-hidden flex flex-col" style={{ border: '1px solid var(--line)', boxShadow: '0 6px 20px rgba(17, 17, 17, 0.04)', height: '100%' }}>
-                  <div className="relative w-full overflow-hidden" style={{ aspectRatio: '4 / 3', background: 'var(--brand-cream)' }}>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={p.img} alt={tHomeProducts(`${p.key}.title`)} className="absolute inset-0 w-full h-full object-cover" loading="lazy" />
-                  </div>
-                  <div className="px-5 pt-5 pb-5 flex flex-col">
-                    <h3 className="text-[17px] m-0" style={{ color: 'var(--brand-ink)', fontWeight: 700, lineHeight: 1.3, letterSpacing: '-0.01em', minHeight: 'calc(1.3em * 2)', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
-                      {tHomeProducts(`${p.key}.title`)}
-                    </h3>
-                    <p className="m-0 mt-3" style={{ color: 'var(--muted)', fontSize: 13.5, lineHeight: 1.6, height: 'calc(1.6em * 2)', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
-                      {tHomeProducts(`${p.key}.description`)}
-                    </p>
-                    <div className="mt-5 pt-4 flex items-center justify-between gap-3" style={{ borderTop: '1px solid var(--line)' }}>
-                      <div className="flex flex-col leading-tight">
-                        <span className="text-[11px]" style={{ color: 'var(--muted)', fontWeight: 500 }}>{tHomeProducts('fromLabel')}</span>
-                        <span className="text-[20px]" style={{ color: 'var(--brand-pink)', fontWeight: 700, letterSpacing: '-0.01em' }}>{stripFromWord(tHomeProducts(p.unit === 'sqft' ? 'priceFromSqft' : 'priceFromFlat', { price: tHomeProducts(`${p.key}.price`) }))}</span>
-                      </div>
-                      <WhatsAppClickTracker phoneNumber={phoneNumber} href={waLink} target="_blank" rel="noopener noreferrer" aria-label={tHomeProducts('bookNow')} className="shrink-0 inline-flex items-center justify-center rounded-full" style={{ background: '#25D366', color: '#fff', width: 44, height: 44, boxShadow: '0 6px 16px rgba(37, 211, 102, 0.30)' }}>
-                        <WAIcon />
-                      </WhatsAppClickTracker>
-                    </div>
-                  </div>
-                </div>
-              </FadeSection>
-            ))}
-          </div>
-        </div>
-      </section>
+      <ServicesGrid products={products} phoneNumber={phoneNumber} waHref={waLink} headingId="loc-products-heading" />
 
       {/* CALCULATOR — same widget as homepage, pre-tied to this location */}
       <section id="calculator" className="py-16 px-6" style={{ background: '#fff', borderTop: '1px solid var(--line)' }} aria-labelledby="loc-calc-heading">

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/page.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/page.tsx
@@ -5,7 +5,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { locations, locationBySlug, cityDisplay } from '@/config/locations'
 import { routing, type Locale } from '@/i18n/routing'
 import { siteConfig } from '@/config/site'
-import { getPhoneNumber } from '@/lib/webcore'
+import { getPhoneNumber, getProducts } from '@/lib/webcore'
 import { LocalBusinessSchema } from '@/components/schema/LocalBusinessSchema'
 import { BreadcrumbSchema } from '@/components/schema/BreadcrumbSchema'
 import { ProductSchema } from '@/components/schema/ProductSchema'
@@ -67,6 +67,7 @@ export default async function LocationPage({ params }: { params: Promise<Params>
   const imageAlt = tRoot('imageAlt')
 
   const { phone } = await getPhoneNumber(location)
+  const products = await getProducts()
   const waHref = `/${locale}/redirect-whatsapp-1?loc=${encodeURIComponent(location)}`
 
   const nearby = loc.nearby
@@ -148,6 +149,7 @@ export default async function LocationPage({ params }: { params: Promise<Params>
         cityName={city}
         phoneNumber={phone}
         nearby={nearby}
+        products={products}
       />
 
       <SiteFooter locale={locale} />

--- a/projects/cat-rumah-malaysia/app/[locale]/page.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { seoAlternates } from '@/lib/seoAlternates'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import { siteConfig } from '@/config/site'
-import { getPhoneNumber } from '@/lib/webcore'
+import { getPhoneNumber, getProducts } from '@/lib/webcore'
 import { OrganizationSchema } from '@/components/schema/OrganizationSchema'
 import { LocalBusinessSchema } from '@/components/schema/LocalBusinessSchema'
 import { ProductSchema } from '@/components/schema/ProductSchema'
@@ -50,6 +50,7 @@ export default async function HomePage({ params }: Props) {
   const imageAlt = tRoot('imageAlt')
 
   const { phone } = await getPhoneNumber()
+  const products = await getProducts()
   const waHref = `/${locale}/redirect-whatsapp-1`
 
   const uspItems = [
@@ -161,7 +162,7 @@ export default async function HomePage({ params }: Props) {
         </div>
       </section>
 
-      <HomePageClient phoneNumber={phone} />
+      <HomePageClient phoneNumber={phone} products={products} />
 
       <SiteFooter locale={locale} />
     </>

--- a/projects/cat-rumah-malaysia/components/ServicesGrid.tsx
+++ b/projects/cat-rumah-malaysia/components/ServicesGrid.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+// The services grid, shared by the homepage and every location page so the two
+// cannot drift apart again. Products arrive from webcore via the server page;
+// see config/products.ts for what this component adds on top of them.
+import { useLocale, useTranslations } from 'next-intl'
+import type { Product } from '@/lib/webcore'
+import { FALLBACK_PRODUCTS, FAMILY_ORDER, SERVICE_META, type Family } from '@/config/products'
+import WhatsAppClickTracker from '@/components/tracking/WhatsAppClickTracker'
+import ProductImpressionTracker from '@/components/tracking/ProductImpressionTracker'
+
+const WAIcon = () => (
+  <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current shrink-0" aria-hidden="true">
+    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
+    <path d="M12 0C5.373 0 0 5.373 0 12c0 2.117.549 4.107 1.508 5.839L.057 23.179c-.083.334.232.633.556.522l5.493-1.757A11.94 11.94 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.9c-1.888 0-3.661-.519-5.175-1.425l-.371-.22-3.842 1.229 1.167-3.77-.242-.389A9.877 9.877 0 012.1 12C2.1 6.534 6.534 2.1 12 2.1S21.9 6.534 21.9 12 17.466 21.9 12 21.9z" />
+  </svg>
+)
+
+// The label above the number already says "from", so the word comes off the
+// rendered price — at the front in ms/en, at the end in zh (起).
+const stripFromWord = (s: string) => s.replace(/^(?:Dari|From)\s+/i, '').replace(/\s*起$/, '')
+
+// Per-sqft rates keep their cents (3.50); flat rates get thousands separators.
+const formatPrice = (n: number) => (n < 100 ? n.toFixed(2) : n.toLocaleString('en-MY'))
+
+type Props = {
+  products: Product[]
+  phoneNumber: string
+  waHref: string
+  headingId: string
+}
+
+export default function ServicesGrid({ products, phoneNumber, waHref, headingId }: Props) {
+  const t = useTranslations('home.products')
+  const locale = useLocale()
+  const source = products.length > 0 ? products : FALLBACK_PRODUCTS
+
+  const items = source.map((p) => {
+    const meta = SERVICE_META[p.slug]
+    const family: Family = meta?.family ?? 'khas'
+    const unit = meta?.unit ?? ((p.sale_price ?? 0) < 100 ? 'sqft' : 'flat')
+    // BM comes from webcore, so an edit there reaches the ms page; en/zh keep
+    // their translations from messages/ for any service this file knows.
+    const title = locale === 'ms' && p.name ? p.name : meta ? t(`${meta.key}.title`) : p.name
+    const description =
+      locale === 'ms' && p.description ? p.description : meta ? t(`${meta.key}.description`) : p.description ?? ''
+    const price =
+      p.sale_price != null
+        ? stripFromWord(t(unit === 'sqft' ? 'priceFromSqft' : 'priceFromFlat', { price: formatPrice(p.sale_price) }))
+        : null
+    return { slug: p.slug, family, title, description, price, photo: p.product_photos[0]?.url ?? null }
+  })
+
+  return (
+    <section id="products" className="py-16 px-6" style={{ background: 'var(--paper-2)' }} aria-labelledby={headingId}>
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-10 max-w-2xl mx-auto text-center">
+          <h3 id={headingId} className="text-2xl md:text-3xl font-bold" style={{ color: 'var(--brand-ink)' }}>{t('heading')}</h3>
+          <p className="mt-3" style={{ color: 'var(--muted)', fontSize: 15.5 }}>{t('subheading')}</p>
+        </div>
+
+        {FAMILY_ORDER.map((fam) => {
+          const group = items.filter((i) => i.family === fam.id)
+          if (group.length === 0) return null
+          return (
+            <div key={fam.id} className="fam-group" style={{ ['--fam' as string]: fam.token }}>
+              <header className="fam-head">
+                <h4>{t(fam.labelKey)}</h4>
+                <span>{group.length} {t('serviceUnit')}</span>
+              </header>
+
+              <div className="swatch-grid">
+                {group.map((i) => (
+                  <ProductImpressionTracker key={i.slug} slug={i.slug}>
+                    <article className="swatch">
+                      <div className="swatch-band" aria-hidden="true" />
+                      {i.photo ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img className="swatch-shot" src={i.photo} alt={i.title} loading="lazy" />
+                      ) : (
+                        <div className="swatch-shot" style={{ background: 'var(--paper-3)' }} aria-hidden="true" />
+                      )}
+                      <div className="swatch-body">
+                        <h5>{i.title}</h5>
+                        <p className="product-desc">{i.description}</p>
+                        <div className="swatch-foot">
+                          {i.price && (
+                            <span className="swatch-price">
+                              <span>{t('fromLabel')}</span>
+                              <b>{i.price}</b>
+                            </span>
+                          )}
+                          <WhatsAppClickTracker
+                            phoneNumber={phoneNumber}
+                            href={waHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={t('bookNow')}
+                            className="shrink-0 inline-flex items-center justify-center rounded-full"
+                            style={{ background: '#25D366', color: '#fff', width: 42, height: 42 }}
+                          >
+                            <WAIcon />
+                          </WhatsAppClickTracker>
+                        </div>
+                      </div>
+                    </article>
+                  </ProductImpressionTracker>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+
+        <p className="mt-10 text-xs max-w-2xl mx-auto text-center" style={{ color: 'var(--muted)' }}>{t('disclaimer')}</p>
+      </div>
+    </section>
+  )
+}

--- a/projects/cat-rumah-malaysia/config/products.ts
+++ b/projects/cat-rumah-malaysia/config/products.ts
@@ -1,168 +1,69 @@
-const W = (id: string) =>
-  `https://static.wixstatic.com/media/${id}/v1/fill/w_800,h_600,al_c,q_85,enc_avif,quality_auto/${id.split('~')[0]}.png`
+// Services grid metadata, keyed by webcore product slug.
+//
+// Webcore (`products` + `product_photos` for this domain) is the source of
+// truth for which services exist, their order, names, prices and photos —
+// CLAUDE.md. This file only adds what webcore has no field for:
+//
+//   - the colour family a service is filed under (the hero's colour key)
+//   - whether its price is per sqft or a flat rate
+//   - the message key its en/zh copy lives under — webcore stores one
+//     language, BM, so the other two locales still come from messages/
+//
+// A product added in webcore without an entry here still renders: it takes
+// its BM name in every locale, files under Khas, and infers its unit from the
+// price.
+import type { Product } from '@/lib/webcore'
 
-export interface ProductImage {
-  url: string
-  alt: Record<string, string>
-}
+export type Family = 'dalam' | 'luar' | 'khas'
 
-export interface PricingTier {
-  labelKey: string
-  priceKey: string
-}
-
-export interface Product {
+export interface ServiceMeta {
   key: string
-  slug: string
-  type: 'main' | 'sub'
-  parentKey?: string
-  mainImage: ProductImage
-  gallery: ProductImage[]
-  pricing: PricingTier[]
+  family: Family
+  unit: 'sqft' | 'flat'
 }
 
-// ─── Main categories ───
-export const products: Product[] = [
-  // ──── CAT DINDING RUMAH (Interior) ────
-  {
-    key: 'interior',
-    slug: 'cat-dinding-rumah',
-    type: 'main',
-    mainImage: {
-      url: W('d3104b_ce500b1b695b487d9a3ff3b4a151e140~mv2.png'),
-      alt: { ms: 'Cat dinding rumah dalaman', en: 'Interior wall painting', zh: '室内墙壁油漆' },
-    },
-    gallery: [
-      { url: W('d3104b_8608aa2d682349a2a436bb813b032ec2~mv2.png'), alt: { ms: 'Contoh cat dinding 1', en: 'Wall paint example 1', zh: '墙漆示例 1' } },
-      { url: W('d3104b_9c4b63ab7d7e494b86acc4ed53b11794~mv2.png'), alt: { ms: 'Contoh cat dinding 2', en: 'Wall paint example 2', zh: '墙漆示例 2' } },
-      { url: W('d3104b_cee8abb743e248e09d41ca90e09ffe36~mv2.png'), alt: { ms: 'Contoh cat dinding 3', en: 'Wall paint example 3', zh: '墙漆示例 3' } },
-    ],
-    pricing: [],
-  },
-  // Texture Painting (sub of interior)
-  {
-    key: 'texture',
-    slug: 'texture-painting',
-    type: 'sub',
-    parentKey: 'interior',
-    mainImage: {
-      url: W('d3104b_7ae8cf5752094994abb1b5fbc95ae6c5~mv2.png'),
-      alt: { ms: 'Texture painting', en: 'Texture painting', zh: '纹理油漆' },
-    },
-    gallery: [
-      { url: W('d3104b_029c732742364e2882941eec7ed0dd21~mv2.png'), alt: { ms: 'Texture contoh 1', en: 'Texture example 1', zh: '纹理示例 1' } },
-      { url: W('d3104b_5c0bd82a7e024d19ac89e63ebc3655c6~mv2.png'), alt: { ms: 'Texture contoh 2', en: 'Texture example 2', zh: '纹理示例 2' } },
-    ],
-    pricing: [
-      { labelKey: 'laborOnly', priceKey: 'laborOnlyPrice' },
-      { labelKey: 'laborAndPaint', priceKey: 'laborAndPaintPrice' },
-    ],
-  },
-  // Marble Painting (sub of interior)
-  {
-    key: 'marble',
-    slug: 'marble-painting',
-    type: 'sub',
-    parentKey: 'interior',
-    mainImage: {
-      url: W('d3104b_dd13cd594b4e474ab9ffa02d8d84e04d~mv2.png'),
-      alt: { ms: 'Marble painting', en: 'Marble painting', zh: '大理石油漆' },
-    },
-    gallery: [],
-    pricing: [
-      { labelKey: 'laborOnly', priceKey: 'laborOnlyPrice' },
-      { labelKey: 'laborAndPaint', priceKey: 'laborAndPaintPrice' },
-    ],
-  },
+export const SERVICE_META: Record<string, ServiceMeta> = {
+  'cat-dinding-rumah': { key: 'interior', family: 'dalam', unit: 'sqft' },
+  'cat-bilik-tidur': { key: 'bedroom', family: 'dalam', unit: 'sqft' },
+  'cat-dapur': { key: 'kitchen', family: 'dalam', unit: 'sqft' },
+  'cat-bilik-mandi': { key: 'bathroom', family: 'dalam', unit: 'sqft' },
+  'cat-luar-rumah': { key: 'exterior', family: 'luar', unit: 'sqft' },
+  'weathershield-paint': { key: 'weathershield', family: 'luar', unit: 'sqft' },
+  'marble-painting': { key: 'marble', family: 'khas', unit: 'flat' },
+  'texture-painting': { key: 'texture', family: 'khas', unit: 'flat' },
+  'dinding-hiasan-3d': { key: 'decor3d', family: 'khas', unit: 'flat' },
+}
 
-  // ──── CAT LUAR RUMAH (Exterior) ────
-  {
-    key: 'exterior',
-    slug: 'cat-luar-rumah',
-    type: 'main',
-    mainImage: {
-      url: W('d3104b_ee5e1611dc524fb68e579cc0b89fd778~mv2.png'),
-      alt: { ms: 'Cat luar rumah', en: 'Exterior wall painting', zh: '外墙油漆' },
-    },
-    gallery: [
-      { url: W('d3104b_9f0f0f98a46f4de18bdc134c045cdc62~mv2.png'), alt: { ms: 'Cat luar contoh 1', en: 'Exterior example 1', zh: '外墙示例 1' } },
-      { url: W('d3104b_f593b0d5314248a5954ce74841072868~mv2.png'), alt: { ms: 'Cat luar contoh 2', en: 'Exterior example 2', zh: '外墙示例 2' } },
-    ],
-    pricing: [],
-  },
-  // Weathershield (sub of exterior)
-  {
-    key: 'weathershield',
-    slug: 'weathershield-paint',
-    type: 'sub',
-    parentKey: 'exterior',
-    mainImage: {
-      url: W('d3104b_1cce0431f1804f489ae75c8ab969bff1~mv2.png'),
-      alt: { ms: 'Cat weathershield', en: 'Weathershield paint', zh: '防风雨漆' },
-    },
-    gallery: [
-      { url: W('d3104b_de2324471cd34394b1df5344c0e15547~mv2.png'), alt: { ms: 'Weathershield contoh 1', en: 'Weathershield example 1', zh: '防风雨漆示例 1' } },
-      { url: W('d3104b_fae01e4b4dcb41a8993238937d5006f0~mv2.png'), alt: { ms: 'Weathershield contoh 2', en: 'Weathershield example 2', zh: '防风雨漆示例 2' } },
-    ],
-    pricing: [],
-  },
-  // Outdoor Metal Paint (sub of exterior)
-  {
-    key: 'metal',
-    slug: 'outdoor-metal-paint',
-    type: 'sub',
-    parentKey: 'exterior',
-    mainImage: {
-      url: W('d3104b_dd13cd594b4e474ab9ffa02d8d84e04d~mv2.png'),
-      alt: { ms: 'Cat besi luar', en: 'Outdoor metal paint', zh: '户外金属漆' },
-    },
-    gallery: [],
-    pricing: [
-      { labelKey: 'laborOnly', priceKey: 'laborOnlyPrice' },
-      { labelKey: 'laborAndPaint', priceKey: 'laborAndPaintPrice' },
-    ],
-  },
-
-  // ──── SECONDARY SERVICES (standalone) ────
-  {
-    key: 'ceiling',
-    slug: 'cat-siling',
-    type: 'main',
-    mainImage: {
-      url: W('d3104b_c84a541538634bd687d4e893aecc4813~mv2.png'),
-      alt: { ms: 'Cat siling rumah', en: 'Ceiling painting', zh: '天花板油漆' },
-    },
-    gallery: [],
-    pricing: [],
-  },
-  {
-    key: 'epoxy',
-    slug: 'cat-epoxy-lantai',
-    type: 'main',
-    mainImage: {
-      url: W('d3104b_472023712aa84fa6a2a9d6ed444544db~mv2.png'),
-      alt: { ms: 'Cat epoxy lantai', en: 'Epoxy floor coating', zh: '环氧地坪漆' },
-    },
-    gallery: [],
-    pricing: [],
-  },
-  {
-    key: 'fence',
-    slug: 'cat-pagar-rumah',
-    type: 'main',
-    mainImage: {
-      url: W('d3104b_e7cc1f1397ac4b9982f6b4df525e0f20~mv2.png'),
-      alt: { ms: 'Cat pagar rumah', en: 'Fence painting', zh: '围栏油漆' },
-    },
-    gallery: [],
-    pricing: [],
-  },
+export const FAMILY_ORDER: { id: Family; token: string; labelKey: string }[] = [
+  { id: 'dalam', token: 'var(--fam-dalam)', labelKey: 'famDalam' },
+  { id: 'luar', token: 'var(--fam-luar)', labelKey: 'famLuar' },
+  { id: 'khas', token: 'var(--fam-khas)', labelKey: 'famKhas' },
 ]
 
-export const swatchChips = [
-  '#17A890',
-  '#EC6A4A',
-  '#F1EAD9',
-  '#1E2430',
-  '#FBF7F0',
+// Rendered only when webcore is unreachable or returns no active products —
+// CLAUDE.md allows a config fallback for exactly that case and nothing else.
+// Name and description are left empty so every locale resolves them from
+// messages/ rather than duplicating copy here.
+const fallback = (slug: string, sort: number, price: number, photo: string): Product => ({
+  id: `fallback-${slug}`,
+  slug,
+  name: '',
+  description: null,
+  sale_price: price,
+  rental_price: null,
+  sort_order: sort,
+  product_photos: [{ url: `/images/products/${photo}` }],
+  prices: [],
+})
+
+export const FALLBACK_PRODUCTS: Product[] = [
+  fallback('cat-dinding-rumah', 1, 3.5, 'interior-1.jpg'),
+  fallback('cat-bilik-tidur', 2, 3.5, 'bedroom-1.jpg'),
+  fallback('cat-dapur', 3, 3.5, 'kitchen-1.jpg'),
+  fallback('cat-bilik-mandi', 4, 3.5, 'bathroom-1.jpg'),
+  fallback('cat-luar-rumah', 5, 3.5, 'exterior-1.jpg'),
+  fallback('weathershield-paint', 6, 4.5, 'exterior-2.jpg'),
+  fallback('marble-painting', 7, 2250, 'marble-1.jpg'),
+  fallback('texture-painting', 8, 2500, 'texture-1.jpg'),
+  fallback('dinding-hiasan-3d', 9, 3500, 'decor3d-1.jpg'),
 ]

--- a/projects/cat-rumah-malaysia/lib/webcore.ts
+++ b/projects/cat-rumah-malaysia/lib/webcore.ts
@@ -220,6 +220,7 @@ export function waLink(phone: string, message?: string): string {
 
 export interface ProductPhoto {
   url: string
+  sort_order?: number | null
 }
 
 export interface PriceLine {
@@ -255,13 +256,19 @@ interface ProductRow {
 
 export async function getProducts(): Promise<Product[]> {
   const path =
-    `products?select=id,slug,name,description,sale_price,rental_price,sort_order,product_photos(url),prices` +
+    `products?select=id,slug,name,description,sale_price,rental_price,sort_order,product_photos(url,sort_order),prices` +
     `&website=eq.${encodeURIComponent(siteConfig.domain)}` +
     `&is_active=eq.true` +
     `&order=sort_order.asc`
   const data = await webcoreFetch<ProductRow[]>(path, 'webcore-products')
   if (!data) return []
-  return data.map((p) => ({ ...p, prices: p.prices ?? [] }))
+  // An embed returns product_photos in no particular order; the first one is
+  // the card image, so sort before anything reads it.
+  return data.map((p) => ({
+    ...p,
+    prices: p.prices ?? [],
+    product_photos: [...(p.product_photos ?? [])].sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0)),
+  }))
 }
 
 /* ============================================================


### PR DESCRIPTION
Closes #83
Closes #84
Closes #103

`CLAUDE.md` makes it a CRITICAL rule that products come from webcore's `products` + `product_photos`, so a product added or deactivated in the database appears or disappears on the site without a code change. The homepage ignored it — nine services were a literal array, and `getProducts()` in `lib/webcore.ts` had **no caller at all**. The location pages had their own copy, still in the pre-redesign card style.

### Data — done through the webcore Token API, not in this diff

Webcore held a different 9 products from the site, every photo on the reference site's Wix CDN. Per the owner: the site's catalogue and prices are correct, and the webcore-only services are deactivated, not deleted.

| | |
|---|---|
| updated (ids kept) | `cat-dinding-rumah`, `cat-luar-rumah`, `weathershield-paint`, `marble-painting`, `texture-painting` — names, descriptions, prices, sort order, photos |
| added | `cat-bilik-tidur`, `cat-dapur`, `cat-bilik-mandi`, `dinding-hiasan-3d` |
| deactivated (ids kept) | `cat-siling`, `cat-epoxy-lantai`, `cat-pagar-rumah`, `outdoor-metal-paint` |
| prices corrected | Marble RM2,000 → **2,250** · Texture RM2,000 → **2,500** · Weathershield empty → **4.50/sqft** |

The pre-change state was saved before the first write, so every change is reversible. Photos are now one per product, served from `https://cat-rumah.my/images/products/`. Every PATCH returned 2xx, and the PATCH route looks a product up by id before updating it — so the four retired rows existed and were updated, not removed. They no longer appear in any public read.

Verified by reading back with the **anon key, exactly as the site does**: 9 active rows, in the site's order, one photo each, all on `cat-rumah.my`.

### Code

- **one shared `ServicesGrid`** used by the homepage and every location page, fed by `getProducts()` on the server — the two pages cannot drift again, and the location pages get the redesign's swatch grid they were missing
- **`config/products.ts` rewritten** — it was dead code with 18 Wix CDN URLs (#84). It now holds only what webcore has no field for: colour family, sqft-vs-flat, and the message key for en/zh copy, keyed by slug — plus the fallback `CLAUDE.md` allows for when webcore is unreachable
- **BM text comes from webcore**, so an edit there reaches the ms page; en/zh keep their translations from `messages/`. A product added in webcore with no config entry still renders (BM name, filed under Khas, unit inferred from the price)
- `getProducts()` now selects photo `sort_order` and sorts — a PostgREST embed returns rows in no guaranteed order and the first photo is the card image
- **no time-based revalidate** — the `no-time-revalidate` guardrail forbids it; the fetches are already tagged `webcore-products`, which webcore purges on every product write

### Verified

Built and served from an isolated worktree off `origin/main`.

- `npm run build` → `✓ Compiled successfully`
- rendered grid read back from the page on `/`, `/en` and `/cat-rumah/ipoh`: 9 tiles in 3 families, prices `RM 3.50/sqft` … `RM 3,500`, photos correct; `/en` shows English titles from `messages/`
- **fallback path tested** by serving with Supabase unset: 9 tiles render from local photos with correct prices
- `no-time-revalidate` passes · no `wixstatic` left in source · one `h1` + one `h2` on both page types · `uwc('impression', …product-)` intact · no undefined CSS variables
- looked at both grids at 1440px

**Not deployed** — merge does not publish. Until it is, the live site still renders the hardcoded list, which currently matches webcore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQT9gkRF4s7Tfv7yH3yoQ1