### PR TITLE
fix(cat-rumah): lay the paint-brand logos out three to a row on mobile

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/page.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/page.tsx
@@ -147,7 +147,10 @@ export default async function HomePage({ params }: Props) {
         <div className="max-w-6xl mx-auto text-center">
           <h3 id="brands-heading" className="text-lg md:text-xl font-bold" style={{ color: 'var(--brand-ink)' }}>{tBrands('heading')}</h3>
           <h5 className="text-xs font-normal mt-2 max-w-2xl mx-auto" style={{ color: 'var(--muted)', lineHeight: 1.6 }}>{tBrands('subheading')}</h5>
-          <div className="mt-6 flex flex-wrap items-center justify-center gap-x-8 gap-y-4">
+          {/* Each logo takes a third of the row on mobile, so five lay out 3 + 2 with
+              the pair centred — a free wrap put four on the first line and left
+              Sissons alone on the second. Desktop sizes to content in one row. */}
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-y-6 sm:gap-x-8">
             {[
               { src: '/images/paint-brands/nippon.png', alt: 'Nippon Paint' },
               { src: '/images/paint-brands/jotun.png', alt: 'Jotun' },
@@ -155,8 +158,10 @@ export default async function HomePage({ params }: Props) {
               { src: '/images/paint-brands/kcc.png', alt: 'KCC Paint' },
               { src: '/images/paint-brands/sissons.png', alt: 'Sissons' },
             ].map((b) => (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img key={b.alt} src={b.src} alt={b.alt} style={{ height: 48, width: 'auto', objectFit: 'contain', filter: 'saturate(0.95)' }} loading="lazy" />
+              <div key={b.alt} className="w-1/3 sm:w-auto flex justify-center px-2 sm:px-0">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={b.src} alt={b.alt} style={{ height: 48, width: 'auto', maxWidth: '100%', objectFit: 'contain', filter: 'saturate(0.95)' }} loading="lazy" />
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
Closes #107

The five-logo strip used a free `flex-wrap`: at phone width four fit on the first line and Sissons dropped to a second line alone.

Each logo now sits in a `w-1/3` cell on mobile, so the five lay out **3 + 2 with the pair centred**; images keep their 48px height and gain `max-width: 100%` so a wide mark can't overflow its cell. From `sm` up the cells size to content and the strip stays one row.

### Verified

Built and served from an isolated worktree off `origin/main`.

- `npm run build` → `✓ Compiled successfully`
- logo centres read from the page at **390px**: row 1 Nippon 81 · Jotun 195 · Dulux 309, row 2 KCC 138 · Sissons 252 — the pair straddles 195, the centre of the viewport
- at **1440px**: one row of five at 560 · 640 · 720 · 800 · 880
- looked at both widths

**Not deployed** — merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQT9gkRF4s7Tfv7yH3yoQ1