### PR TITLE
fix(cat-rumah): replace the long dashes in the site copy

### DIFF
--- a/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/HomePageClient.tsx
@@ -197,7 +197,7 @@ function CostCalculator({ locale, phoneNumber }: { locale: string; phoneNumber: 
           >
             <optgroup label="Per sqft">
               {sqftServices.map((s) => (
-                <option key={s.key} value={s.key}>{tProducts(`${s.key}.title`)} — RM{s.rate}{t('perSqftSuffix')}</option>
+                <option key={s.key} value={s.key}>{tProducts(`${s.key}.title`)} (RM{s.rate}{t('perSqftSuffix')})</option>
               ))}
             </optgroup>
             <optgroup label="Pakej">

--- a/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
+++ b/projects/cat-rumah-malaysia/app/[locale]/cat-rumah/[location]/LocationPageClient.tsx
@@ -252,7 +252,7 @@ export default function LocationPageClient({ locale, locationSlug, cityName, pho
                   <select id="loc-calc-service" value={calcServiceKey} onChange={(e) => setCalcServiceKey(e.target.value)} className="calc-select w-full px-4 py-3 rounded-xl text-sm font-semibold">
                     <optgroup label="Per sqft">
                       {sqftServices.map((s) => (
-                        <option key={s.key} value={s.key}>{tHomeProducts(`${s.key}.title`)} — RM{s.rate}{tCalc('perSqftSuffix')}</option>
+                        <option key={s.key} value={s.key}>{tHomeProducts(`${s.key}.title`)} (RM{s.rate}{tCalc('perSqftSuffix')})</option>
                       ))}
                     </optgroup>
                     <optgroup label="Pakej">

--- a/projects/cat-rumah-malaysia/components/schema/LocalBusinessSchema.tsx
+++ b/projects/cat-rumah-malaysia/components/schema/LocalBusinessSchema.tsx
@@ -15,7 +15,7 @@ export function LocalBusinessSchema({
     '@context': 'https://schema.org',
     '@type': 'LocalBusiness',
     name: cityName
-      ? `${siteConfig.brandName} — ${cityName}`
+      ? `${siteConfig.brandName} ${cityName}`
       : siteConfig.brandName,
     url: locationSlug
       ? `${siteConfig.siteUrl}/${locale}/${siteConfig.productSlug}/${locationSlug}`

--- a/projects/cat-rumah-malaysia/config/site.ts
+++ b/projects/cat-rumah-malaysia/config/site.ts
@@ -6,7 +6,7 @@ export const siteConfig = {
   // Stable webcore identity (company_websites.id). Never changes on domain rename.
   siteId: '54c0e27d-64bd-491e-a97a-8fe6d4e92650',
   brandName: 'Cat Rumah Express',
-  tagline: 'Rumah Baru dalam 1 Hari — Dari RM3.50/sqft',
+  tagline: 'Rumah Baru dalam 1 Hari, dari RM3.50/sqft',
   domain: 'cat-rumah.my',
   baseUrl: 'https://cat-rumah.my',
   siteUrl: 'https://cat-rumah.my',

--- a/projects/cat-rumah-malaysia/messages/en.json
+++ b/projects/cat-rumah-malaysia/messages/en.json
@@ -1,6 +1,6 @@
 {
   "logoAlt": "Cat Rumah Malaysia logo",
-  "imageAlt": "House painting Malaysia — professional painting contractor",
+  "imageAlt": "House painting Malaysia, professional painting contractor",
   "nav": {
     "logoAlt": "Cat Rumah Malaysia logo",
     "home": "Home",
@@ -12,11 +12,11 @@
     "whatsappCta": "WhatsApp"
   },
   "products": {
-    "imageAltTemplate": "{model} house painting — Cat Rumah Malaysia"
+    "imageAltTemplate": "{model} house painting by Cat Rumah Malaysia"
   },
   "gallery": {
     "alts": [
-      "Interior living room paint job — neat finish",
+      "Interior living room paint job with a neat finish",
       "Exterior paint job on double-storey terrace",
       "White anti-mould ceiling painting",
       "Auto-gate metal fence repaint",
@@ -31,7 +31,7 @@
     ]
   },
   "footer": {
-    "tagline": "Professional house painting contractor across Malaysia — interior, exterior, ceiling, epoxy floor, and fence painting with Nippon, Jotun, and Dulux.",
+    "tagline": "Professional house painting contractor across Malaysia: interior, exterior, ceiling, epoxy floor, and fence painting with Nippon, Jotun, and Dulux.",
     "description": "Professional house painting contractor across Malaysia. Interior, exterior, ceiling, epoxy floor, and fence painting using Nippon, Jotun, and Dulux premium paints.",
     "whatsappUs": "WhatsApp Us",
     "productsHeading": "Services",
@@ -53,11 +53,11 @@
   },
   "home": {
     "meta": {
-      "title": "House Painting Malaysia | From RM3.50/sqft — Cat Rumah Malaysia",
+      "title": "House Painting Malaysia | From RM3.50/sqft | Cat Rumah Malaysia",
       "description": "Malaysia house painting service from RM3.50/sqft. Interior, exterior, ceiling, epoxy floor & fence painting. Nippon, Jotun, Dulux. WhatsApp now."
     },
     "fomo": {
-      "promo": "This month — free quote within 1 hour.",
+      "promo": "This month: free quote within 1 hour.",
       "slotsLeft": "Only {slots} slots left this week!",
       "bookNow": "Book now"
     },
@@ -67,7 +67,7 @@
       "badgeCities": "20+ Cities Covered",
       "headline": "Make Your Old Home",
       "headlineHighlight": "Look New",
-      "subheadline": "Malaysia's professional house painting contractor — Nippon Paint, Jotun, and Dulux. Free quote within 1 hour, fixed pricing with no hidden costs.",
+      "subheadline": "Malaysia's professional house painting contractor, using Nippon Paint, Jotun, and Dulux. Free quote within 1 hour, fixed pricing with no hidden costs.",
       "tag1": "Done in 5 Hours",
       "tag2": "180 Colour Choices",
       "tag3": "Free Pressure Wash",
@@ -81,19 +81,19 @@
     },
     "usp": {
       "usp1Title": "Free Quote",
-      "usp1Sub": "Send photos via WhatsApp — we reply with an estimate within 1 hour.",
+      "usp1Sub": "Send photos via WhatsApp and we reply with an estimate within 1 hour.",
       "usp2Title": "Premium Paint",
-      "usp2Sub": "Nippon Paint, Jotun, Dulux only — never cheap economy paints.",
+      "usp2Sub": "Nippon Paint, Jotun, and Dulux only. Never cheap economy paints.",
       "usp3Title": "1-Year Warranty",
       "usp3Sub": "Scratches or peeling within 12 months? We repaint for free."
     },
     "products": {
       "tag": "OUR SERVICES",
       "heading": "8 House Painting Services",
-      "subheading": "From living room to exterior — one team, one guarantee for every surface.",
+      "subheading": "From living room to exterior: one team, one guarantee for every surface.",
       "interior": {
         "title": "Interior Wall Painting",
-        "description": "Living rooms, hallways, and accent walls — premium Nippon Odour-less with neat finishing.",
+        "description": "Living rooms, hallways, and accent walls in premium Nippon Odour-less, with neat finishing.",
         "price": "3.50"
       },
       "bedroom": {
@@ -108,17 +108,17 @@
       },
       "bathroom": {
         "title": "Bathroom Painting",
-        "description": "Anti-fungal, humidity-resistant — Jotun Drygolin or Dulux Easycare.",
+        "description": "Anti-fungal and humidity-resistant: Jotun Drygolin or Dulux Easycare.",
         "price": "3.50"
       },
       "exterior": {
         "title": "Exterior House Painting",
-        "description": "Built for Malaysian weather — pressure wash included free.",
+        "description": "Built for Malaysian weather, with a free pressure wash included.",
         "price": "3.50"
       },
       "weathershield": {
         "title": "Weathershield Premium",
-        "description": "Jotun Jotashield or Nippon Weatherbond — 7–10 year guarantee.",
+        "description": "Jotun Jotashield or Nippon Weatherbond, with a 7-10 year guarantee.",
         "price": "4.50"
       },
       "marble": {
@@ -133,7 +133,7 @@
       },
       "decor3d": {
         "title": "3D Decorative Wall",
-        "description": "Embossed 3D panel finish — monstera, geometric, or organic motifs.",
+        "description": "Embossed 3D panel finish in monstera, geometric, or organic motifs.",
         "price": "3,500"
       },
       "bookNow": "Get a Quote",
@@ -174,7 +174,7 @@
       "heading": "Why Choose Cat Rumah Malaysia",
       "reason1": {
         "title": "Premium Brands Only",
-        "description": "We use Nippon Paint, Jotun, and Dulux — never cheap economy paints."
+        "description": "We use Nippon Paint, Jotun, and Dulux, never cheap economy paints."
       },
       "reason2": {
         "title": "Done in 5 Hours",
@@ -208,7 +208,7 @@
       "step2Desc": "Free site visit. Pick your colours and lock in a fixed price.",
       "step3Num": "03",
       "step3Title": "Done in 5 Hours",
-      "step3Desc": "Small jobs same day. Larger projects finished in 1–3 days.",
+      "step3Desc": "Small jobs same day. Larger projects finished in 1-3 days.",
       "cta": "WhatsApp Us Now"
     },
     "reviews": {
@@ -226,7 +226,7 @@
       "review3Text": "Weathershield job for our double-storey. Team came on time and finished a day early. 5 stars deserved.",
       "review3Name": "Mr Lim",
       "review3Location": "Johor Bahru",
-      "review4Text": "Thought house painting was expensive. Cat Rumah Malaysia quoted RM3.50/sqft — saved RM5k vs other contractors.",
+      "review4Text": "Thought house painting was expensive. Cat Rumah Malaysia quoted RM3.50/sqft and saved me RM5k vs other contractors.",
       "review4Name": "Siti N.",
       "review4Location": "Shah Alam",
       "review5Text": "Other contractors quoted RM8k, Cat Rumah Malaysia gave RM4.5k for our terrace house. Premium Nippon paint used.",
@@ -240,9 +240,9 @@
     "gallery": {
       "tag": "OUR WORK",
       "heading": "See Our Recent Jobs",
-      "imageAlt": "House painting work {number} — Cat Rumah Malaysia",
+      "imageAlt": "House painting work {number} by Cat Rumah Malaysia",
       "alts": [
-        "Interior living room paint job — neat finish",
+        "Interior living room paint job with a neat finish",
         "Exterior paint job on double-storey terrace",
         "White anti-mould ceiling painting",
         "Auto-gate metal fence repaint",
@@ -264,13 +264,13 @@
       "q2": "Do you use Nippon, Jotun, or Dulux?",
       "a2": "Yes, all three premium brands. Customers can choose based on budget and surface type.",
       "q3": "How long does it take to repaint a house?",
-      "a3": "Bedroom or living room work: 5 hours. Single-storey terrace: 1–2 days. Double-storey: 2–4 days depending on size.",
+      "a3": "Bedroom or living room work: 5 hours. Single-storey terrace: 1-2 days. Double-storey: 2-4 days depending on size.",
       "q4": "Is the quote chargeable?",
       "a4": "No. Site visits and quotes are free with no obligation.",
       "q5": "What warranty do you offer?",
       "a5": "12-month warranty on all work. Scratches or peeling in that period are repainted free of charge.",
       "q6": "Do you serve outside the Klang Valley?",
-      "a6": "Yes — we cover Penang, Johor Bahru, Ipoh, Melaka, and Seremban. Travel costs are bundled into the quote.",
+      "a6": "Yes, we cover Penang, Johor Bahru, Ipoh, Melaka, and Seremban. Travel costs are bundled into the quote.",
       "q7": "Can I choose my own colours?",
       "a7": "Of course. Our team brings fan decks to site, or you can send WhatsApp inspiration photos.",
       "q8": "Do you remove furniture during work?",
@@ -286,14 +286,14 @@
     "finalCta": {
       "headline": "Ready for a",
       "headlineHighlight": "Newer Home?",
-      "subheadline": "Get a free quote within 1 hour — no obligation, no upfront deposit.",
+      "subheadline": "Get a free quote within 1 hour. No obligation, no upfront deposit.",
       "cta": "WhatsApp Us Now",
       "fine": "Free quote · 1-hour response · 12-month warranty"
     }
   },
   "location": {
     "meta": {
-      "title": "House Painting {city} | From RM3.50/sqft — Cat Rumah Malaysia",
+      "title": "House Painting {city} | From RM3.50/sqft | Cat Rumah Malaysia",
       "description": "Looking for a house painting contractor in {city}? Cat Rumah Malaysia offers interior, exterior, ceiling, and fence painting from RM3.50/sqft."
     },
     "hero": {
@@ -307,26 +307,26 @@
     },
     "services": {
       "heading": "House Painting Services In {city}",
-      "interior": "Interior wall painting in {city} — Nippon Odour-less premium, neat finish.",
-      "exterior": "Exterior house painting in {city} — weathershield for Malaysian climate.",
-      "ceiling": "Ceiling painting in {city} — clean white, anti-mould.",
-      "fence": "Fence and grille painting in {city} — anti-rust, colour lasting 3+ years."
+      "interior": "Interior wall painting in {city} with premium Nippon Odour-less and a neat finish.",
+      "exterior": "Exterior house painting in {city} with weathershield made for the Malaysian climate.",
+      "ceiling": "Ceiling painting in {city}: clean white and anti-mould.",
+      "fence": "Fence and grille painting in {city}: anti-rust, with colour lasting 3+ years."
     },
     "why": {
       "heading": "Why Choose Us In {city}",
-      "fast": "Fast response — on site in {city} within 24 hours.",
-      "transparent": "Fixed pricing — no hidden costs.",
+      "fast": "Fast response, on site in {city} within 24 hours.",
+      "transparent": "Fixed pricing with no hidden costs.",
       "brands": "All premium brands available in {city}.",
       "warranty": "12-month warranty on every {city} job."
     },
     "faq": {
-      "heading": "FAQ — House Painting {city}",
+      "heading": "FAQ: House Painting {city}",
       "q1": "How fast can you reach {city}?",
       "a1": "We have teams near {city} and can be on site within 24 hours.",
       "q2": "How much does house painting cost in {city}?",
       "a2": "Interior walls start from RM3.50/sqft in {city}. Exterior starts from RM4.50/sqft.",
       "q3": "Do you cover all areas of {city}?",
-      "a3": "Yes — full {city} and surrounding postcodes.",
+      "a3": "Yes, all of {city} and the surrounding postcodes.",
       "q4": "Which paint brands do you use in {city}?",
       "a4": "We use Nippon Paint, Jotun, and Dulux across {city}."
     },

--- a/projects/cat-rumah-malaysia/messages/ms.json
+++ b/projects/cat-rumah-malaysia/messages/ms.json
@@ -1,6 +1,6 @@
 {
   "logoAlt": "Logo Cat Rumah Malaysia",
-  "imageAlt": "Cat rumah Malaysia — kontraktor cat profesional",
+  "imageAlt": "Cat rumah Malaysia, kontraktor cat profesional",
   "nav": {
     "logoAlt": "Logo Cat Rumah Malaysia",
     "home": "Utama",
@@ -12,11 +12,11 @@
     "whatsappCta": "WhatsApp"
   },
   "products": {
-    "imageAltTemplate": "Cat rumah {model} — Cat Rumah Malaysia"
+    "imageAltTemplate": "Cat rumah {model} oleh Cat Rumah Malaysia"
   },
   "gallery": {
     "alts": [
-      "Cat dinding dalaman ruang tamu — kemasan rapi",
+      "Cat dinding dalaman ruang tamu dengan kemasan rapi",
       "Cat luar rumah teres dua tingkat",
       "Cat siling putih kalis kulat",
       "Cat pagar besi auto-gate warna baru",
@@ -31,7 +31,7 @@
     ]
   },
   "footer": {
-    "tagline": "Kontraktor cat rumah profesional di seluruh Malaysia. Cat dinding dalam & luar, siling, epoxy lantai, dan pagar — guna Nippon, Jotun, Dulux.",
+    "tagline": "Kontraktor cat rumah profesional di seluruh Malaysia. Cat dinding dalam & luar, siling, epoxy lantai dan pagar dengan Nippon, Jotun dan Dulux.",
     "description": "Kontraktor cat rumah profesional di seluruh Malaysia. Cat dinding dalam & luar, siling, epoxy lantai, dan pagar. Jenama premium Nippon, Jotun, Dulux.",
     "whatsappUs": "WhatsApp Kami",
     "productsHeading": "Servis",
@@ -57,7 +57,7 @@
       "description": "Servis cat rumah Malaysia Dari RM3.50/sqft. Cat dinding, luar, siling, epoxy lantai & pagar. Nippon, Jotun, Dulux. WhatsApp sekarang."
     },
     "fomo": {
-      "promo": "Promo bulan ini — quote percuma dalam 1 jam.",
+      "promo": "Promo bulan ini: quote percuma dalam 1 jam.",
       "slotsLeft": "Hanya {slots} slot lagi untuk minggu ini!",
       "bookNow": "Tempah sekarang"
     },
@@ -83,17 +83,17 @@
       "usp1Title": "Quote Percuma",
       "usp1Sub": "Hantar gambar via WhatsApp, kami balas dengan anggaran dalam 1 jam.",
       "usp2Title": "Cat Premium",
-      "usp2Sub": "Nippon Paint, Jotun, Dulux — bukan cat ekonomi murahan.",
+      "usp2Sub": "Nippon Paint, Jotun dan Dulux. Bukan cat ekonomi murahan.",
       "usp3Title": "Jaminan 1 Tahun",
       "usp3Sub": "Calar atau tompok dalam 12 bulan? Kami cat semula percuma."
     },
     "products": {
       "tag": "SERVIS KAMI",
       "heading": "9 Servis Cat Rumah Kami",
-      "subheading": "Dari ruang tamu sampai eksterior — satu pasukan, satu jaminan untuk setiap permukaan.",
+      "subheading": "Dari ruang tamu sampai eksterior: satu pasukan, satu jaminan untuk setiap permukaan.",
       "interior": {
         "title": "Cat Dinding Dalaman",
-        "description": "Ruang tamu, lorong dan dinding aksen — Nippon Odour-less premium tanpa bau yang menyengat.",
+        "description": "Ruang tamu, lorong dan dinding aksen dengan Nippon Odour-less premium, tanpa bau yang menyengat.",
         "price": "3.50"
       },
       "bedroom": {
@@ -108,7 +108,7 @@
       },
       "bathroom": {
         "title": "Cat Bilik Mandi",
-        "description": "Cat anti-kulat dan tahan kelembapan — Jotun Drygolin atau Dulux Easycare.",
+        "description": "Cat anti-kulat dan tahan kelembapan: Jotun Drygolin atau Dulux Easycare.",
         "price": "3.50"
       },
       "exterior": {
@@ -118,7 +118,7 @@
       },
       "weathershield": {
         "title": "Weathershield Premium",
-        "description": "Jotun Jotashield atau Nippon Weatherbond — tahan 7-10 tahun dengan jaminan.",
+        "description": "Jotun Jotashield atau Nippon Weatherbond, tahan 7-10 tahun dengan jaminan.",
         "price": "4.50"
       },
       "marble": {
@@ -133,7 +133,7 @@
       },
       "decor3d": {
         "title": "3D Decorative Wall",
-        "description": "Panel hiasan 3D timbul — pilihan corak monstera, geometri atau organik.",
+        "description": "Panel hiasan 3D timbul dengan pilihan corak monstera, geometri atau organik.",
         "price": "3,500"
       },
       "bookNow": "Tanya Harga Sekarang",
@@ -174,7 +174,7 @@
       "heading": "Kenapa Pilih Cat Rumah Malaysia",
       "reason1": {
         "title": "Jenama Premium Sahaja",
-        "description": "Kami hanya pakai Nippon Paint, Jotun dan Dulux — bukan cat ekonomi murah."
+        "description": "Kami hanya pakai Nippon Paint, Jotun dan Dulux, bukan cat ekonomi murah."
       },
       "reason2": {
         "title": "Siap Sepantas 5 Jam",
@@ -208,7 +208,7 @@
       "step2Desc": "Lawatan tapak percuma. Pilih warna dan dapatkan harga tetap.",
       "step3Num": "03",
       "step3Title": "Siap Sepantas 5 Jam",
-      "step3Desc": "Kerja kecil siap hari sama. Projek besar disiapkan dalam 1–3 hari.",
+      "step3Desc": "Kerja kecil siap hari sama. Projek besar disiapkan dalam 1-3 hari.",
       "cta": "WhatsApp Kami Sekarang"
     },
     "reviews": {
@@ -240,9 +240,9 @@
     "gallery": {
       "tag": "GALERI KERJA",
       "heading": "Lihat Kerja Kami",
-      "imageAlt": "Kerja cat rumah {number} — Cat Rumah Malaysia",
+      "imageAlt": "Kerja cat rumah {number} oleh Cat Rumah Malaysia",
       "alts": [
-        "Cat dinding dalaman ruang tamu — kemasan rapi",
+        "Cat dinding dalaman ruang tamu dengan kemasan rapi",
         "Cat luar rumah teres dua tingkat",
         "Cat siling putih kalis kulat",
         "Cat pagar besi auto-gate warna baru",
@@ -264,7 +264,7 @@
       "q2": "Adakah anda guna cat Nippon Paint, Jotun atau Dulux?",
       "a2": "Ya, kami pakai ketiga-tiga jenama premium ini. Pelanggan boleh pilih ikut bajet.",
       "q3": "Berapa lama untuk siapkan cat satu rumah?",
-      "a3": "Kerja bilik atau ruang tamu siap dalam 5 jam. Rumah teres satu tingkat 1–2 hari. Rumah dua tingkat 2–4 hari.",
+      "a3": "Kerja bilik atau ruang tamu siap dalam 5 jam. Rumah teres satu tingkat 1-2 hari. Rumah dua tingkat 2-4 hari.",
       "q4": "Adakah quote dikenakan caj?",
       "a4": "Tidak. Lawatan tapak dan sebut harga adalah percuma tanpa ikatan.",
       "q5": "Apa jaminan yang anda beri?",
@@ -286,14 +286,14 @@
     "finalCta": {
       "headline": "Sedia Untuk Rumah",
       "headlineHighlight": "Baru?",
-      "subheadline": "Dapatkan quote percuma dalam 1 jam — tanpa ikatan, tanpa deposit dahulu.",
+      "subheadline": "Dapatkan quote percuma dalam 1 jam. Tanpa ikatan, tanpa deposit dahulu.",
       "cta": "WhatsApp Kami Sekarang",
       "fine": "Quote percuma · Respons dalam 1 jam · Jaminan 12 bulan"
     }
   },
   "location": {
     "meta": {
-      "title": "Cat Rumah {city} | Servis Dari RM3.50/sqft — Cat Rumah Malaysia",
+      "title": "Cat Rumah {city} | Servis Dari RM3.50/sqft | Cat Rumah Malaysia",
       "description": "Cari kontraktor cat rumah di {city}? Cat Rumah Malaysia menawarkan servis cat dinding, luar, siling dan pagar Dari RM3.50/sqft."
     },
     "hero": {
@@ -307,20 +307,20 @@
     },
     "services": {
       "heading": "Servis Cat Rumah Di {city}",
-      "interior": "Cat dinding dalaman di {city} — Nippon Odour-less premium, kemasan rapi.",
-      "exterior": "Cat luar rumah di {city} — weathershield tahan cuaca Malaysia.",
-      "ceiling": "Cat siling di {city} — putih bersih, kalis kulat.",
-      "fence": "Cat pagar dan grill di {city} — anti-karat, warna tahan 3+ tahun."
+      "interior": "Cat dinding dalaman di {city} dengan Nippon Odour-less premium dan kemasan rapi.",
+      "exterior": "Cat luar rumah di {city} dengan weathershield tahan cuaca Malaysia.",
+      "ceiling": "Cat siling di {city}: putih bersih dan kalis kulat.",
+      "fence": "Cat pagar dan grill di {city}: anti-karat, warna tahan 3+ tahun."
     },
     "why": {
       "heading": "Kenapa Pilih Kami Di {city}",
-      "fast": "Respons pantas — sampai {city} dalam masa 24 jam.",
+      "fast": "Respons pantas, sampai {city} dalam masa 24 jam.",
       "transparent": "Harga tetap, tanpa kos tersembunyi.",
       "brands": "Semua jenama premium dilayan di {city}.",
       "warranty": "Jaminan 12 bulan untuk setiap kerja di {city}."
     },
     "faq": {
-      "heading": "Soalan Lazim — Cat Rumah {city}",
+      "heading": "Soalan Lazim: Cat Rumah {city}",
       "q1": "Berapa cepat anda sampai {city}?",
       "a1": "Kami ada pasukan dekat {city} dan boleh datang dalam masa 24 jam.",
       "q2": "Berapa kos cat rumah di {city}?",

--- a/projects/cat-rumah-malaysia/messages/zh.json
+++ b/projects/cat-rumah-malaysia/messages/zh.json
@@ -1,6 +1,6 @@
 {
   "logoAlt": "Cat Rumah Malaysia 标志",
-  "imageAlt": "马来西亚房屋油漆服务 — 专业油漆承包商",
+  "imageAlt": "马来西亚房屋油漆服务，专业油漆承包商",
   "nav": {
     "logoAlt": "Cat Rumah Malaysia 标志",
     "home": "首页",
@@ -12,11 +12,11 @@
     "whatsappCta": "WhatsApp"
   },
   "products": {
-    "imageAltTemplate": "{model} 房屋油漆 — Cat Rumah Malaysia"
+    "imageAltTemplate": "{model} 房屋油漆，由 Cat Rumah Malaysia 施工"
   },
   "gallery": {
     "alts": [
-      "客厅室内油漆 — 细致完工",
+      "客厅室内油漆，细致完工",
       "双层排屋外墙油漆",
       "白色防霉天花板油漆",
       "电动闸门金属围栏重漆",
@@ -31,7 +31,7 @@
     ]
   },
   "footer": {
-    "tagline": "马来西亚专业房屋油漆承包商 — 室内、室外、天花板、环氧地板与围栏油漆，使用立邦、Jotun与多乐士。",
+    "tagline": "马来西亚专业房屋油漆承包商：室内、室外、天花板、环氧地板与围栏油漆，使用立邦、Jotun与多乐士。",
     "description": "马来西亚专业房屋油漆承包商。室内、室外、天花板、环氧地板和围栏油漆。立邦、Jotun、多乐士高级品牌。",
     "whatsappUs": "WhatsApp 我们",
     "productsHeading": "服务",
@@ -57,7 +57,7 @@
       "description": "马来西亚房屋油漆服务，RM3.50/平方尺起。墙壁、外墙、天花板、地板与围栏。立邦、Jotun、多乐士。立即 WhatsApp。"
     },
     "fomo": {
-      "promo": "本月促销 — 1小时内免费报价。",
+      "promo": "本月促销：1小时内免费报价。",
       "slotsLeft": "本周仅剩 {slots} 个名额！",
       "bookNow": "立即预约"
     },
@@ -83,17 +83,17 @@
       "usp1Title": "免费报价",
       "usp1Sub": "WhatsApp发送照片，1小时内回复估价。",
       "usp2Title": "高级油漆",
-      "usp2Sub": "立邦、Jotun、多乐士 — 绝非廉价经济漆。",
+      "usp2Sub": "立邦、Jotun、多乐士，绝非廉价经济漆。",
       "usp3Title": "1年保固",
       "usp3Sub": "12个月内出现刮痕或脱落？免费重新油漆。"
     },
     "products": {
       "tag": "我们的服务",
       "heading": "8项房屋油漆服务",
-      "subheading": "从客厅到外墙 — 一支团队，一项保证。",
+      "subheading": "从客厅到外墙：一支团队，一项保证。",
       "interior": {
         "title": "室内墙壁油漆",
-        "description": "客厅、走廊与重点墙 — 立邦无味高级漆，细致完工。",
+        "description": "客厅、走廊与重点墙：立邦无味高级漆，细致完工。",
         "price": "3.50"
       },
       "bedroom": {
@@ -108,17 +108,17 @@
       },
       "bathroom": {
         "title": "浴室油漆",
-        "description": "防霉防潮 — Jotun Drygolin 或 Dulux Easycare。",
+        "description": "防霉防潮：Jotun Drygolin 或 Dulux Easycare。",
         "price": "3.50"
       },
       "exterior": {
         "title": "外墙油漆",
-        "description": "为马来西亚气候设计 — 含免费高压清洗。",
+        "description": "为马来西亚气候设计，含免费高压清洗。",
         "price": "3.50"
       },
       "weathershield": {
         "title": "高级耐候漆",
-        "description": "Jotun Jotashield 或立邦 Weatherbond — 7–10年保修。",
+        "description": "Jotun Jotashield 或立邦 Weatherbond，7-10年保修。",
         "price": "4.50"
       },
       "marble": {
@@ -133,7 +133,7 @@
       },
       "decor3d": {
         "title": "3D 装饰墙",
-        "description": "立体浮雕墙板 — 龟背叶、几何或有机图案。",
+        "description": "立体浮雕墙板：龟背叶、几何或有机图案。",
         "price": "3,500"
       },
       "bookNow": "立即询价",
@@ -174,11 +174,11 @@
       "heading": "为什么选择 Cat Rumah Malaysia",
       "reason1": {
         "title": "仅用高级品牌",
-        "description": "我们仅使用立邦、Jotun和多乐士 — 绝非廉价漆。"
+        "description": "我们仅使用立邦、Jotun和多乐士，绝非廉价漆。"
       },
       "reason2": {
         "title": "5小时完成",
-        "description": "卧室或客厅工作 — 您当天就能搬回新家。"
+        "description": "卧室或客厅工作，您当天就能搬回新家。"
       },
       "reason3": {
         "title": "免费报价，无任何承诺",
@@ -194,7 +194,7 @@
       },
       "reason6": {
         "title": "全马来西亚覆盖",
-        "description": "从吉隆坡到槟城 — 我们送上门服务。"
+        "description": "从吉隆坡到槟城，我们送上门服务。"
       }
     },
     "howItWorks": {
@@ -226,7 +226,7 @@
       "review3Text": "双层楼的耐候漆工作。团队准时到场，提前一天完工。值得5星。",
       "review3Name": "Mr Lim",
       "review3Location": "新山",
-      "review4Text": "我以为油漆很贵。Cat Rumah Malaysia 报价 RM3.50/平方尺 — 比其他承包商省了5千。",
+      "review4Text": "我以为油漆很贵。Cat Rumah Malaysia 报价 RM3.50/平方尺，比其他承包商省了5千。",
       "review4Name": "Siti N.",
       "review4Location": "莎阿南",
       "review5Text": "其他承包商报价8千，Cat Rumah Malaysia 只要4.5千做我们的排屋。用的还是立邦高级漆。",
@@ -240,9 +240,9 @@
     "gallery": {
       "tag": "工程展示",
       "heading": "查看我们的近期作品",
-      "imageAlt": "房屋油漆作品 {number} — Cat Rumah Malaysia",
+      "imageAlt": "房屋油漆作品 {number}，由 Cat Rumah Malaysia 施工",
       "alts": [
-        "客厅室内油漆 — 细致完工",
+        "客厅室内油漆，细致完工",
         "双层排屋外墙油漆",
         "白色防霉天花板油漆",
         "电动闸门金属围栏重漆",
@@ -268,9 +268,9 @@
       "q4": "报价是否收费？",
       "a4": "不收费。现场考察与报价都是免费的，没有义务。",
       "q5": "你们提供什么保修？",
-      "a5": "12个月保修。期间出现刮痕或脱落 — 免费重新油漆。",
+      "a5": "12个月保修。期间出现刮痕或脱落，免费重新油漆。",
       "q6": "巴生谷以外的地区是否服务？",
-      "a6": "是的 — 我们覆盖槟城、新山、怡保、马六甲和芙蓉。差旅费已含在报价中。",
+      "a6": "是的，我们覆盖槟城、新山、怡保、马六甲和芙蓉。差旅费已含在报价中。",
       "q7": "可以自己选颜色吗？",
       "a7": "当然。我们带色卡上门，或您可以WhatsApp发送参考图。",
       "q8": "工作期间会搬动家具吗？",
@@ -286,14 +286,14 @@
     "finalCta": {
       "headline": "准备好",
       "headlineHighlight": "焕新家居？",
-      "subheadline": "1小时内获得免费报价 — 无任何承诺，无预付金。",
+      "subheadline": "1小时内获得免费报价。无任何承诺，无预付金。",
       "cta": "立即 WhatsApp 我们",
       "fine": "免费报价 · 1小时回复 · 12个月保修"
     }
   },
   "location": {
     "meta": {
-      "title": "{city} 房屋油漆 | RM3.50/平方尺起 — Cat Rumah Malaysia",
+      "title": "{city} 房屋油漆 | RM3.50/平方尺起 | Cat Rumah Malaysia",
       "description": "寻找 {city} 房屋油漆承包商？Cat Rumah Malaysia 提供墙壁、外墙、天花板和围栏油漆服务，RM3.50/平方尺起。"
     },
     "hero": {
@@ -307,15 +307,15 @@
     },
     "services": {
       "heading": "{city} 房屋油漆服务",
-      "interior": "{city} 室内墙壁油漆 — 立邦无味高级漆，细致完工。",
-      "exterior": "{city} 室外油漆 — 耐候漆适应马来西亚气候。",
-      "ceiling": "{city} 天花板油漆 — 洁白防霉。",
-      "fence": "{city} 围栏与栏杆油漆 — 防锈，颜色持久3年以上。"
+      "interior": "{city} 室内墙壁油漆：立邦无味高级漆，细致完工。",
+      "exterior": "{city} 室外油漆：耐候漆适应马来西亚气候。",
+      "ceiling": "{city} 天花板油漆：洁白防霉。",
+      "fence": "{city} 围栏与栏杆油漆：防锈，颜色持久3年以上。"
     },
     "why": {
       "heading": "为什么在 {city} 选择我们",
-      "fast": "响应迅速 — 24小时内到达 {city}。",
-      "transparent": "固定价格 — 无隐藏费用。",
+      "fast": "响应迅速，24小时内到达 {city}。",
+      "transparent": "固定价格，无隐藏费用。",
       "brands": "{city} 提供所有高级品牌。",
       "warranty": "{city} 每项工作12个月保修。"
     },


### PR DESCRIPTION
Closes #106

The site owner wants the em and en dashes gone from the copy.

### What changed

| where | |
|---|---|
| `messages/ms.json` | 24 strings |
| `messages/en.json` | 32 strings |
| `messages/zh.json` | 28 strings |
| `LocalBusinessSchema` name | `Cat Rumah Malaysia — <city>` → `Cat Rumah Malaysia <city>` |
| `config/site.ts` tagline | `… 1 Hari — Dari RM3.50/sqft` → `… 1 Hari, dari RM3.50/sqft` |
| calculator dropdown (JSX text) | `Cat Dapur — RM3.5/sqft` → `Cat Dapur (RM3.5/sqft)` |
| **webcore** — 4 product descriptions | done through the Token API, not in this diff; they render on the ms grid since #104 |

A dash can't just be deleted, so each was replaced for what it was doing:

| role | before | after |
|---|---|---|
| elaboration / list | `Promo bulan ini — quote percuma dalam 1 jam.` | `Promo bulan ini: quote percuma dalam 1 jam.` |
| aside | `Yes — we cover Penang, …` | `Yes, we cover Penang, …` |
| two thoughts | `… dalam 1 jam — tanpa ikatan, …` | `… dalam 1 jam. Tanpa ikatan, …` |
| joining a noun phrase | `Panel hiasan 3D timbul — pilihan corak …` | `Panel hiasan 3D timbul dengan pilihan corak …` |
| zh | `本月促销 — 1小时内免费报价。` | `本月促销：1小时内免费报价。` |
| range | `1–3 hari` | `1-3 hari` |
| title separator | `… RM3.50/sqft — Cat Rumah Malaysia` | `… RM3.50/sqft \| Cat Rumah Malaysia` |

Every rewrite was asserted to keep its ICU placeholders (`{city}`, `{model}`, `{number}`).

### Left for a separate decision: the blog

The 10 blog posts carry roughly 190 em and 25 en dashes in their titles, excerpts and bodies. That is long-form article content in the production CMS, not site copy, so it is not touched here and is raised with the owner separately.

### Verified

Built and served from an isolated worktree off `origin/main`.

- `npm run build` → `✓ Compiled successfully`
- **long dashes counted in the rendered HTML** of `/`, `/en`, `/zh`, `/cat-rumah/ipoh` in all three locales, `/blog` and `/en/blog`: **zero** on every page — the commit step was gated on it
- the six calculator options per page render in brackets
- webcore descriptions read back after the PATCH: zero dashes, photos untouched

**Not deployed** — merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQT9gkRF4s7Tfv7yH3yoQ1