### PR TITLE
Record oxygentank.com.my's GTM container, Ads conversion and superseded GA4 property

### DIFF
--- a/scripts/google-automation/configs/oxygentank.com.my.json
+++ b/scripts/google-automation/configs/oxygentank.com.my.json
@@ -1,0 +1,50 @@
+{
+  "domain": "oxygentank.com.my",
+  "containerId": "GTM-NGHMQ8JZ",
+  "gtmAccountId": "6000211475",
+  "ga4MeasurementId": "G-LWKS7S79DR",
+  "events": [
+    {
+      "redirectPath": "/redirect-whatsapp-1",
+      "eventName": "whatsapp_click"
+    }
+  ],
+  "ga4": {
+    "accountId": "153453478",
+    "accountName": "Utopia 1st Analytics",
+    "propertyId": "553551450",
+    "propertyName": "properties/553551450",
+    "measurementId": "G-LWKS7S79DR",
+    "streamName": "properties/553551450/dataStreams/15751579559",
+    "siteUrl": "https://www.oxygentank.com.my",
+    "createdAt": "2026-09-10T06:42:46.015Z"
+  },
+  "gsc": {
+    "siteUrl": "https://www.oxygentank.com.my/zh/",
+    "token": "<meta name=\"google-site-verification\" content=\"FgkJjHkVlXbiDGlBefrc9v8MzajrgYfdoJNpJxTjDaI\" />",
+    "initAt": "2026-09-10T06:50:28.643Z",
+    "verified": true,
+    "verificationMethod": "META",
+    "verifiedAt": "2026-09-10T06:54:02.751Z"
+  },
+  "gtm": {
+    "containerNumericId": "263491290",
+    "workspaceId": "3",
+    "measurementIdVariableId": "3",
+    "note": "Created by a partial run on 2026-09-08, before this config existed, so there is no createdAt. gtm-setup.mjs aborts on it with 'Found entity with duplicate name' — inspect it, do not recreate it. The service account has read-only access to this container: edits need getUserAuth(), and publishing needs a token with tagmanager.publish (the saved OAuth token does not have it) or the GTM UI. 2026-09-10: workspace 3's Constant_Measurement ID was repointed to G-LWKS7S79DR; live version 2 still carried G-TQ3Y9846V7 until a new version is published."
+  },
+  "ads": {
+    "customerId": "1933757591",
+    "conversionActionId": "7757047633",
+    "name": "oxygentank.com.my (web) whatsapp_click",
+    "importsFromGa4Property": "553551450",
+    "note": "Auto-imported from GA4 on 2026-09-10. An auto-imported action's property and event cannot be changed in place: moving it to another property means unlinking and relinking GA4 to Ads, which imports a new action with a new ID."
+  },
+  "supersededGa4": {
+    "propertyId": "552927173",
+    "measurementId": "G-TQ3Y9846V7",
+    "streamId": "15737060249",
+    "createdAt": "2026-09-08T04:59:49.180Z",
+    "note": "Created by the 2026-09-08 partial run. Still the GA4 property webcore has registered for this site, and it received the site's traffic for as long as GTM's live version pointed at it. It has only the default 'purchase' key event, so nothing imports from it. Do not delete it until webcore has been reconnected to 553551450 (admin UI only — there is no API for it) and the repointed GTM measurement ID is published."
+  }
+}


### PR DESCRIPTION
Closes #108

## What was missing

`gtm-setup.mjs` aborted on this site with `Found entity with duplicate name` — container `GTM-NGHMQ8JZ` already existed from a partial run on 2026-09-08 — and it only writes the config at the very end. So `configs/oxygentank.com.my.json` held just the `ga4` and `gsc` blocks, none of the top-level keys every other site carries, and it was never committed. The GTM container and the Ads conversion existed only in an agent's session report.

## What this adds

The fleet's top-level keys in exactly the shape `gtm-setup.mjs` writes (compare `cat-rumah.my.json`):

```
domain · containerId · gtmAccountId · ga4MeasurementId · events: [{ redirectPath, eventName }]
```

Plus three blocks that survive a re-run, because `ga4-create.mjs` and `gsc-submit.mjs` both spread the existing config:

| Block | Records |
|---|---|
| `gtm` | numeric container / workspace / variable ids; the service account can only **read** this container |
| `ads` | conversion `7757047633`, and why it cannot be repointed in place |
| `supersededGa4` | `552927173` from the partial run, and why it must not be deleted yet |

No top-level `createdAt` — the container predates this config and its creation time is recorded nowhere, so it is left out rather than invented.

## Every value checked against its live source

| Value | Checked against | Result |
|---|---|---|
| `GTM-NGHMQ8JZ`, account `6000211475`, workspace 3, variable 3 | GTM API | ✓ |
| `553551450` / `G-LWKS7S79DR`, stream `15751579559` | Analytics Admin API | ✓ — key events `purchase`, `whatsapp_click`; 14-month retention |
| `552927173` / `G-TQ3Y9846V7`, stream `15737060249`, created 2026-09-08 04:59Z | Analytics Admin API | ✓ — key events `purchase` only |
| Ads conversion bound to `553551450` | GA4 `googleAdsLinks` | ✓ — only `553551450` is linked to customer `1933757591`; `552927173` has no link |
| Conversion `7757047633` | Google Ads API | ✓ — ENABLED · GA4 custom · CONTACT · primary · 90-day lookback |
| GSC verification token | live site HTML | ✓ — served on `/` |

Also checked: valid JSON; each top-level key has the same type as `cat-rumah.my.json`; no secret-looking strings; `heading-audit.mjs`, the only script that reads configs, picks the domain up.

## Not fixed here

- **Re-runs can still create duplicates.** Neither `ga4-create.mjs` nor `gtm-setup.mjs` checks for an existing resource. This PR is a record, not a guard — that is #109.
- **Operational state, recorded but not changed by this PR:** GTM's live version 2 still sends to `G-TQ3Y9846V7`; the repointed draft in workspace 3 awaits a publish. The conversion still counts `MANY_PER_CLICK` rather than One.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdeCFgbF3CuD2qBiXCSJtX