### PR TITLE
docs: one branch per site for site fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,14 @@ The system should scale to:
 - Keep prompts modular and reusable
 - Store brand guidelines in `brand_assets/` before starting a project
 - Each project gets its own subfolder under `projects/`
+- **One site, one branch.** A fix to a site under `projects/<site>/` goes on its
+  own branch and PR, named for the site (`fix/<site>-<what>`). Never bundle
+  several sites' fixes into one branch — not even the same fix repeated: 11
+  sites means 11 branches. Each site is then reviewed, merged and deployed on its
+  own schedule, which matters because some sites auto-deploy on merge (revmove)
+  and some have another session mid-work on them. Repo-wide work that is not a
+  site fix — flow docs, `scripts/`, `agents/`, `templates/` — stays one branch
+  per purpose.
 
 
 # Technology Stack


### PR DESCRIPTION
Closes #117

Adds a convention to `CLAUDE.md` → Conventions: a fix to a site under
`projects/<site>/` gets its own branch and PR, named for the site, even when the
same fix repeats across sites. Repo-wide work (flow docs, `scripts/`, `agents/`,
`templates/`) stays one branch per purpose.

Why: #116 bundled a schema fix for 11 sites, so none of them can be merged or
deployed without the rest — a real cost where a site auto-deploys on merge
(revmove) or another session is mid-work on it (cat-rumah).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgwfUgJf3Ui1AsTjqB6kFz