### PR TITLE
docs: make keyword push and live revalidation mandatory, owned steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,9 @@ Product data on every website MUST be fetched dynamically from the Supabase `pro
 
 ## Rules
 1. Homepage and location pages query `products` WHERE `website = domain` AND `is_active = true` ORDER BY `sort_order`, joined with `product_photos`
-2. Use ISR with `revalidate = 3600` (1 hour) so DB changes propagate without redeploy
+2. Tag every webcore fetch (`webcore-products`, `webcore-phones`, `webcore-blog`, `webcore-seo`) and let webcore purge them through the site's `/api/revalidate` — a DB change lands within seconds, with no redeploy. No time-based `export const revalidate = N` (the wizard's `no-time-revalidate` check fails on it). Live revalidation is wired at deploy — Step 14.
 3. Grid layout must auto-adjust to any product count — use CSS grid auto-fill or responsive columns that handle 1, 6, or 20 products gracefully
-4. Adding a product in the database → it appears on the site automatically (within revalidate window)
+4. Adding a product in the database → it appears on the site automatically (as soon as webcore's revalidation ping purges the tag)
 5. Setting `is_active = false` or deleting → it disappears automatically
 6. `config/products.ts` may exist ONLY as a fallback if Supabase is unreachable — it is NOT the source of truth
 7. Product images come from `product_photos.url` — never hardcode image URLs in frontend code

--- a/agents/gloo.md
+++ b/agents/gloo.md
@@ -15,8 +15,9 @@
 > `GET /api/public/phone-numbers?website=<candidate>` before writing; an empty
 > array means wrong key and the write will orphan silently.
 >
-> Yours: `PUT /api/website-settings { website, revalidate_url }` (auto-generates
-> the revalidate secret and returns it if the site has none),
+> Yours: re-run `PUT /api/website-settings { website, revalidate_url }` only if the
+> paid domain differs from the host Layla wired at deploy — Layla owns the first
+> registration (Step 14), because Gloo runs too late for it,
 > `POST /api/integrations/gsc/submit-sitemap { domain }` (site must already be
 > GSC-connected — OAuth consent stays in the admin UI), and
 > `POST /api/integrations/marketing/mark-key-event { domain, eventName }` (the

--- a/agents/layla.md
+++ b/agents/layla.md
@@ -15,7 +15,9 @@
 > `GET /api/public/phone-numbers?website=<candidate>` before writing; an empty
 > array means wrong key and the write will orphan silently.
 >
-> Yours: verify live revalidation end-to-end before you call a deploy done.
+> Yours: wire live revalidation — register the URL with `PUT /api/website-settings`,
+> set the returned secret in Vercel Production, redeploy — then verify it end-to-end
+> before you call a deploy done.
 > `GET /api/public/phone-numbers/resolve?website=<d>` must return the expected
 > number, and a POST to the site's own `/api/revalidate` with the shared secret
 > must answer `200 {"revalidated":[...]}`. A `401` almost always means the
@@ -127,11 +129,13 @@ After the code is pushed to GitHub:
 - Set the required environment variables:
   - `NEXT_PUBLIC_SUPABASE_URL`
   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `WEBCORE_REVALIDATE_SECRET` — from the `PUT /api/website-settings` response
   - Any other project-specific env vars
 - Trigger the deployment
 - Wait for the build to complete
 - Verify the deployed site loads correctly
 - Check that the production WhatsApp button still connects to the correct phone numbers
+- **Wire live revalidation (MANDATORY)** — register `https://<d>/api/revalidate` with `PUT /api/website-settings`, set the secret in Production, redeploy, then POST the route with the secret and require `200 {"revalidated":[...]}`. Full steps: `docs/full-website-setup.md` → Step 14 → Live revalidation. A `404` means the site has no route — add one from the template before calling it done.
 
 **Report the final deployment URL to the user.**
 
@@ -142,6 +146,7 @@ Return a status report with:
 1. **Integration test results** — pass/fail for each check, with details on any failures
 2. **GitHub push** — commit hash, branch, repo URL
 3. **Vercel deployment** — deployment URL, build status, any errors
+4. **Live revalidation** — the POST result (`200 revalidated` / `401` / `500` / `404`) and the tags it returned
 
 ---
 

--- a/agents/sora.md
+++ b/agents/sora.md
@@ -66,6 +66,14 @@ at 110/mo as #1 while `harga kambing aqiqah` at 480/mo sat lower). If the
 orchestrator hands you volume numbers, re-rank the plan to match them and record
 the figures in the document.
 
+### 1b. Push the verified keywords to webcore (MANDATORY — once the gate passes)
+The plan file is invisible to webcore. As soon as Step B2's gate passes, push the
+verified terms: `keyword-volume.mjs --plan <seo-plan.md> --website <registered-domain> --push`,
+once per language (`--lang ms --only ms`, then `--lang en --only en`), with a
+`--dry-run` first. Verify with a cache-busted `GET /api/public/keywords` and report
+the stored primary/secondary counts. Never hand-write the POST — a body with
+`keywords` instead of `rows` returns `200` and stores nothing.
+
 ### 2. Page hierarchy
 Map keywords to pages:
 ```

--- a/docs/full-website-setup.md
+++ b/docs/full-website-setup.md
@@ -211,6 +211,29 @@ node keyword-volume.mjs --ideas "pakej aqiqah" --lang ms
 Then edit `seo-plan.md` and re-run until the gate passes. Record the numbers in
 the plan so Nana, Kimmy and Hanabi inherit verified terms.
 
+**Then push the verified terms to webcore (MANDATORY — Sora).** The plan file is
+invisible to webcore; its keyword store is what webcore's SEO tooling, the wizard
+and every later session read. This step being optional is why 21 fleet sites had
+no keywords in webcore at all (audit, 2026-09-11).
+
+```bash
+# once per language webcore stores (ms, en) — --dry-run first to inspect the payload
+node keyword-volume.mjs --plan .../projects/{slug}/seo-plan.md --lang ms --only ms \
+  --website <registered-domain> --push --dry-run
+node keyword-volume.mjs --plan .../projects/{slug}/seo-plan.md --lang ms --only ms \
+  --website <registered-domain> --push
+node keyword-volume.mjs --plan .../projects/{slug}/seo-plan.md --lang en --only en \
+  --website <registered-domain> --push
+# verify — the public GET is CDN-cached for 300s, so bust it
+curl -s "$WEBCORE_BASE_URL/api/public/keywords?website=<registered-domain>&_cb=$RANDOM"
+```
+
+Head terms land in `primary_keywords`, the rest in `secondary_keywords`, and only
+terms at or above `--min` are pushed. Use the script, not a hand-written POST: a
+body that says `keywords` instead of `rows` returns `200` and stores nothing, and
+primary/secondary lists over 32 lose their tail silently (`docs/webcore-api.md`).
+webcore stores `en` and `ms` only.
+
 > Requires the head terms to sit under a heading Sora marks as primary (e.g.
 > `### 1.2 Primary money keywords`). If the script warns that no head-term
 > section was found, nothing can fail the gate — fix the plan's headings or pass
@@ -1083,7 +1106,7 @@ VALUES
 - Use `is_active = true` for products to display
 - `sort_order` controls display order
 - Product images go in `product_photos` table, NOT hardcoded in frontend
-- Use ISR with `revalidate = 3600` — products appear within 1 hour of DB change
+- No time-based ISR. Fetches are tagged `webcore-products` and webcore purges them through `/api/revalidate` within seconds of a DB change (wired at Step 14). Never add `export const revalidate = N` — the wizard's `no-time-revalidate` check fails on it.
 
 ### Verify
 - All product rows exist in Supabase
@@ -1229,7 +1252,11 @@ Spawn **Layla** (QA & Deployment Specialist) only after user confirms in Gate 2.
 5. Push code to GitHub
 6. Deploy to Vercel
 7. Add Supabase env vars to Vercel: `vercel env add`
-8. Report the live URL
+8. **Wire live revalidation (MANDATORY)** — register the site's revalidate URL in
+   webcore, set the secret as `WEBCORE_REVALIDATE_SECRET` in Vercel **Production**,
+   redeploy, and prove it (below). Without it every webcore edit waits for the
+   next rebuild; 18 fleet sites were in that state (audit, 2026-09-11).
+9. Report the live URL
 
 ### Vercel Environment Variables
 
@@ -1238,7 +1265,31 @@ Add these to Vercel for the project:
 ```
 NEXT_PUBLIC_SUPABASE_URL=https://xzydvhzcngpxdbyniliy.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY={anon_key}
+WEBCORE_REVALIDATE_SECRET={from step 1 of Live revalidation below}
 ```
+
+### Live revalidation (MANDATORY)
+
+```bash
+set -a && . ./.env.local && set +a
+# 1. register — webcore generates a secret if the site has none and returns it
+#    (if the site already has one, read it from the webcore admin)
+curl -s -X PUT "$WEBCORE_BASE_URL/api/website-settings" \
+  -H "x-api-key: $WEBCORE_API_KEY" -H "Content-Type: application/json" \
+  -d '{ "website": "<d>", "revalidate_url": "https://<d>/api/revalidate" }'
+# 2. vercel env add WEBCORE_REVALIDATE_SECRET production     (paste the secret)
+# 3. redeploy — env changes only reach deployments made after them
+# 4. prove it
+curl -s -X POST "https://<d>/api/revalidate" -H "X-Webcore-Secret: <secret>" \
+  -H "Content-Type: application/json" -d '{"tags":["webcore-products"]}'
+```
+
+`200 {"revalidated":[...]}` = wired · `401` = secret mismatch (prod env never set,
+or not redeployed) · `500` = env var missing · `404` = no
+`app/api/revalidate/route.ts`. The route's allow-list must name all four tags —
+`webcore-products`, `webcore-phones`, `webcore-blog`, `webcore-seo` — because a
+tag missing from it is accepted with a `200` and silently dropped. Re-run step 1
+whenever the domain changes. Reference: `docs/webcore-api.md` → Live revalidation.
 
 ---
 


### PR DESCRIPTION
Closes #119

The 2026-09-11 audit found **21 sites with no keywords in webcore** and **18 whose
`/api/revalidate` can't receive a purge**. Both trace to the flow: keyword push
was an optional flag, and revalidation was a header note owned by the agent that
runs last.

## Changes

| Where | What |
|---|---|
| Step B2 · `sora.md` | Pushing the verified terms to webcore is a numbered **mandatory** step: per language, `--dry-run` first, cache-busted verify, and the `rows`-vs-`keywords` trap named |
| Step 14 · `layla.md` | Wiring revalidation is checklist item 8, with a full register → secret → redeploy → prove sequence, what each status code means, the four-tag allow-list rule, and a line in Layla's report |
| `gloo.md` | Layla owns the first registration; Gloo only re-registers if the paid domain differs |
| `CLAUDE.md` · Step 5 rules | "ISR `revalidate = 3600`" replaced with the tag-based model the wizard's `no-time-revalidate` check actually enforces |

Docs only — no code, env or schema. The fleet backfill and the wizard checks
that stop this recurring are separate PRs (one per site, per #118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgwfUgJf3Ui1AsTjqB6kFz