### PR TITLE
Record revmove.my's Ads conversion block from Phase 5

### DIFF
--- a/scripts/google-automation/configs/revmove.my.json
+++ b/scripts/google-automation/configs/revmove.my.json
@@ -9,5 +9,13 @@
       "eventName": "whatsapp_click"
     }
   ],
-  "createdAt": "2026-08-19T09:06:31.463Z"
+  "createdAt": "2026-08-19T09:06:31.463Z",
+  "ads": {
+    "customerId": "1933757591",
+    "ga4PropertyId": "550737214",
+    "conversionActionId": "7758862467",
+    "conversionActionName": "revmove.my (web) whatsapp_click",
+    "event": "whatsapp_click",
+    "importedAt": "2026-09-11T03:34:23.232Z"
+  }
 }


### PR DESCRIPTION
Closes #129

Adds the `ads` block Phase 5 wrote to `scripts/google-automation/configs/revmove.my.json` (customer, GA4 property, conversion action id/name, event, importedAt). Config only; no secrets — same shape as the other sites' configs. Phase 6 exited 0 with all four toggles `done-ui`, Phase 7 ticked the card (`ready`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)