### PR TITLE
chore(guardrails): regenerate for the two live webcore checks

### DIFF
--- a/docs/guardrails.html
+++ b/docs/guardrails.html
@@ -61,9 +61,9 @@
 </header>
 <div class="wrap">
   <div class="stats">
-    <div class="stat"><div class="n">114</div><div class="l">Total rules</div></div>
+    <div class="stat"><div class="n">116</div><div class="l">Total rules</div></div>
     <div class="stat block"><div class="n">62</div><div class="l">Blocking</div></div>
-    <div class="stat adv"><div class="n">52</div><div class="l">Advisory</div></div>
+    <div class="stat adv"><div class="n">54</div><div class="l">Advisory</div></div>
     <div class="stat"><div class="n">11</div><div class="l">Categories</div></div>
   </div>
 
@@ -717,7 +717,7 @@
       </table>
     </section>
     <section class="group" data-group="Database">
-      <h2>Database <span class="gcount">5 rules · 5 blocking</span></h2>
+      <h2>Database <span class="gcount">6 rules · 5 blocking</span></h2>
       <table>
         <thead><tr><th>Severity</th><th>Rule</th><th>Check id</th><th>Doc</th></tr></thead>
         <tbody>
@@ -751,11 +751,17 @@
         <td><code>db-products</code></td>
         <td><a href="full-website-setup.md" target="_blank" rel="noopener">docs ↗</a></td>
       </tr>
+      <tr class="rule" data-sev="advisory" data-text="keyword research is in webcore webcore-keywords-present">
+        <td><span class="badge sev-adv">advisory</span></td>
+        <td class="rule-name">Keyword research is in webcore</td>
+        <td><code>webcore-keywords-present</code></td>
+        <td><a href="full-website-setup.md" target="_blank" rel="noopener">docs ↗</a></td>
+      </tr>
         </tbody>
       </table>
     </section>
     <section class="group" data-group="Deployment">
-      <h2>Deployment <span class="gcount">8 rules · 7 blocking</span></h2>
+      <h2>Deployment <span class="gcount">9 rules · 7 blocking</span></h2>
       <table>
         <thead><tr><th>Severity</th><th>Rule</th><th>Check id</th><th>Doc</th></tr></thead>
         <tbody>
@@ -800,6 +806,12 @@
         <td class="rule-name">Live site shows what webcore holds</td>
         <td><code>webcore-products-live</code></td>
         <td><a href="full-website-setup.md" target="_blank" rel="noopener">docs ↗</a></td>
+      </tr>
+      <tr class="rule" data-sev="advisory" data-text="live /api/revalidate can receive a purge live-revalidate-reachable">
+        <td><span class="badge sev-adv">advisory</span></td>
+        <td class="rule-name">Live /api/revalidate can receive a purge</td>
+        <td><code>live-revalidate-reachable</code></td>
+        <td><a href="full-website-setup.md#16-step-14--deploy" target="_blank" rel="noopener">docs ↗</a></td>
       </tr>
       <tr class="rule" data-sev="blocking" data-text="whatsapp prefill names the originating domain wa-prefill-carries-domain">
         <td><span class="badge sev-block">BLOCKING</span></td>


### PR DESCRIPTION
Closes #131

`npm run guardrails` in utopia-wizard at `main` (`183eee6`, after
utopiagrowth/utopia-wizard#22). Adds `live-revalidate-reachable` (Deployment)
and `webcore-keywords-present` (Database) to the page — 116 rules, 62 blocking,
54 advisory. Generated file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)