### PR TITLE
feat(electric-wheelchair): Plus Jakarta Sans headings and an orange steps section

### DIFF
--- a/projects/electric-wheelchair-malaysia/app/[locale]/layout.tsx
+++ b/projects/electric-wheelchair-malaysia/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import { Inter } from 'next/font/google';
+import { Inter, Plus_Jakarta_Sans } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -10,6 +10,15 @@ const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-inter',
+});
+
+// Heading face. Inter stays for body copy; headings, prices and buttons take
+// this one via --font-heading in globals.css (CLAUDE.md: distinct heading face).
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  weight: ['700', '800'],
+  display: 'swap',
+  variable: '--font-jakarta',
 });
 
 export default async function LocaleLayout({
@@ -28,7 +37,7 @@ export default async function LocaleLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale} className={inter.variable}>
+    <html lang={locale} className={`${inter.variable} ${jakarta.variable}`}>
       <head>
         <meta
           name="google-site-verification"

--- a/projects/electric-wheelchair-malaysia/app/[locale]/page.tsx
+++ b/projects/electric-wheelchair-malaysia/app/[locale]/page.tsx
@@ -293,7 +293,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       </section>
 
       {/* ── Delivery steps ─────────────────────────────────────────────── */}
-      <section className="ew-sec ew-sec--paper" id="how-it-works">
+      <section className="ew-sec ew-steps" id="how-it-works">
         <div className="ew-wrap">
           <div className="ew-head">
             <h3>{tSteps('heading')}</h3>

--- a/projects/electric-wheelchair-malaysia/app/globals.css
+++ b/projects/electric-wheelchair-malaysia/app/globals.css
@@ -969,11 +969,17 @@ a {
   --ink-muted: #4A5873;
   --hair: rgba(11, 32, 69, 0.13);
   --hair-strong: rgba(11, 32, 69, 0.22);
-  --font-heading: var(--font-inter), Inter, system-ui, sans-serif;
+  --font-heading: var(--font-jakarta), "Plus Jakarta Sans", var(--font-inter), Inter, system-ui, sans-serif;
 }
 
 /* CLAUDE.md, Text Spacing: headings tight, body comfortable. */
 h1, h2, h3, h4, h5, h6 { line-height: 1.2; }
+
+/* Two faces: Plus Jakarta Sans for display, Inter for reading. The hero h2 is
+   a subtitle rather than a title, so it stays in the body face; everything
+   else that behaves like a title — headings, prices, buttons — takes the
+   heading face. */
+h1, h3, h4, h5, h6, .ew-rate b, .wa-btn, .ghost-btn { font-family: var(--font-heading); }
 p, li, blockquote,
 .blog-content p, .blog-content li, .blog-content blockquote { line-height: 1.4; }
 
@@ -1137,6 +1143,13 @@ p, li, blockquote,
 .ew-specs dd { font-size: 15px; color: var(--brand-navy); margin: 0; }
 
 /* ── Delivery steps ──────────────────────────────────────────────────────── */
+/* The one section on the brand orange. Copy on it is navy, never the muted
+   grey: #4A5873 on #FF6613 is 2.9:1, navy is 4.9:1. Cards stay white so the
+   photos and their captions keep their own contrast. */
+.ew-steps { background: var(--brand-orange); }
+.ew-steps .ew-head p { color: rgba(11, 32, 69, 0.85); }
+.ew-steps .ew-steps__cta p { color: rgba(11, 32, 69, 0.85); }
+.ew-steps .ew-step { box-shadow: 0 10px 28px rgba(11, 32, 69, 0.16), 0 2px 6px rgba(11, 32, 69, 0.08); }
 .ew-steps__list { display: grid; gap: 18px; margin: 0; padding: 0; list-style: none; }
 .ew-step {
   background: #fff; border-radius: 20px; overflow: hidden;


### PR DESCRIPTION
Closes #137

Headings, prices, buttons and the contact number render in Plus Jakarta Sans (loaded via `next/font`, weights 700/800); the hero h2 and body stay Inter. The delivery steps section becomes the one orange ground on the page, with navy copy and white cards.

### Verified
- `npm run build` passes (258 pages)
- Computed styles on the served build: h1/h3/price/contact = Plus Jakarta Sans 800, buttons 700, h2 and body = Inter 400, steps background `rgb(255,102,19)`
- One h1 and one h2; no horizontal overflow at 390px or 1440px; looked at both

Not deployed — merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)