### PR TITLE
fix(electric-wheelchair): show the Google mark beside the reviews rating

### DIFF
--- a/projects/electric-wheelchair-malaysia/app/[locale]/page.tsx
+++ b/projects/electric-wheelchair-malaysia/app/[locale]/page.tsx
@@ -61,6 +61,18 @@ function Stars({ label }: { label: string }) {
   );
 }
 
+/** The four-colour Google "G" — marks where the rating comes from. */
+function GoogleMark({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" role="img" aria-label="Google">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
 function WhatsAppIcon({ size = 20 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -420,6 +432,9 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           <figure className="ew-rev__quote">
             <span className="ew-eyebrow">{tReviews('eyebrow')}</span>
             <div className="ew-rating">
+              <span className="ew-rating__g">
+                <GoogleMark />
+              </span>
               <b>{tReviews('rating')}</b>
               <Stars label={starLabel} />
               <span>{tReviews('ratingSuffix')}</span>

--- a/projects/electric-wheelchair-malaysia/app/globals.css
+++ b/projects/electric-wheelchair-malaysia/app/globals.css
@@ -1293,3 +1293,11 @@ p, li, blockquote,
 .ew-hero__copy .ew-eyebrow { margin-bottom: 2px; }
 .ew-steps .ew-eyebrow { background: #fff; color: var(--brand-navy); }
 .ew-eyebrow--on-dark { background: rgba(255, 255, 255, 0.14); color: #fff; }
+
+/* Google mark in the reviews rating row: a white disc so the four colours sit
+   clean on the pale-blue band, with a little more room before the 4.9. */
+.ew-rating__g {
+  display: inline-grid; place-items: center; width: 36px; height: 36px;
+  border-radius: 50%; background: #fff; margin-right: 4px;
+  box-shadow: 0 1px 2px rgba(15, 15, 15, 0.08);
+}


### PR DESCRIPTION
Closes #143

The four-colour Google G on a white disc, before the 4.9 and the stars in the reviews band.

### Verified
- `npm run build` passes; served build renders the mark (`aria-label="Google"`), one h1 and one h2, no overflow at 390px or 1440px; looked at both.

Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)