### PR TITLE
Add a deploy wrapper for sites under projects/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,51 @@ Database:
 Supabase
 
 Deployment:
-Vercel
+Vercel — CLI only, via `scripts/deploy-site.sh` (see Deployment below)
+
+
+# Deployment (CRITICAL)
+
+**Vercel is not connected to GitHub.** Merging to `main` publishes nothing.
+A site goes live only when someone runs the deploy script.
+
+```bash
+scripts/deploy-site.sh <site>              # deploy projects/<site> to production
+scripts/deploy-site.sh <site> --preview    # preview deploy
+scripts/deploy-site.sh <site> --dry-run    # stage + preflight only, no deploy
+```
+
+## Never run a raw `vercel --prod`
+
+It is rejected as **Blocked** / "Not authorized" before the build runs. Vercel
+reads the git HEAD commit author on every CLI deploy, and only the CLI login
+`chokchokchok` (`utopiacoliving@gmail.com`) is a paid member of the
+`chokchunynh` team. No commit author in this repo is that identity — the repo
+root is `atyn.utopia@gmail.com`, and sites carrying their own `.git` are
+`atyn.utopia@`, `chokchunynh@` or `design.utco@`. All 42 sites are affected.
+
+Hiding a site's own `.git` does not help either: a site without one resolves up
+to the repo root, so the CLI still finds an author one level up.
+
+The script sidesteps this by staging the site's files into a temp directory that
+is not inside any git repo, then deploying from there — the CLI finds no commit
+author and falls back to the logged-in identity. **The repo's `.git` is never
+moved or modified**, which matters because it is shared by all 42 sites and by
+any other session working in this checkout.
+
+## Rules
+
+1. One site, one deploy. The script refuses two site arguments — each site goes
+   live on its own schedule.
+2. The site must be linked (`projects/<site>/.vercel/project.json`). If it is
+   not, the script stops rather than letting the CLI create a duplicate project
+   under the team. Link with `cd projects/<site> && vercel link`.
+3. **Do not connect a Vercel project to GitHub.** It re-enables the
+   commit-author block.
+4. `.env.local` is never uploaded. Production values belong in the Vercel
+   project — set them with `printf`, not `echo` (`echo` appends a newline).
+5. Verify against the **Ready URL the script prints**. Never guess a live URL
+   from the project name.
 
 
 # Dynamic Product Data (CRITICAL)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,51 @@ Database:
 Supabase
 
 Deployment:
-Vercel
+Vercel — CLI only, via `scripts/deploy-site.sh` (see Deployment below)
+
+
+# Deployment (CRITICAL)
+
+**Vercel is not connected to GitHub.** Merging to `main` publishes nothing.
+A site goes live only when someone runs the deploy script.
+
+```bash
+scripts/deploy-site.sh <site>              # deploy projects/<site> to production
+scripts/deploy-site.sh <site> --preview    # preview deploy
+scripts/deploy-site.sh <site> --dry-run    # stage + preflight only, no deploy
+```
+
+## Never run a raw `vercel --prod`
+
+It is rejected as **Blocked** / "Not authorized" before the build runs. Vercel
+reads the git HEAD commit author on every CLI deploy, and only the CLI login
+`chokchokchok` (`utopiacoliving@gmail.com`) is a paid member of the
+`chokchunynh` team. No commit author in this repo is that identity — the repo
+root is `atyn.utopia@gmail.com`, and sites carrying their own `.git` are
+`atyn.utopia@`, `chokchunynh@` or `design.utco@`. All 42 sites are affected.
+
+Hiding a site's own `.git` does not help either: a site without one resolves up
+to the repo root, so the CLI still finds an author one level up.
+
+The script sidesteps this by staging the site's files into a temp directory that
+is not inside any git repo, then deploying from there — the CLI finds no commit
+author and falls back to the logged-in identity. **The repo's `.git` is never
+moved or modified**, which matters because it is shared by all 42 sites and by
+any other session working in this checkout.
+
+## Rules
+
+1. One site, one deploy. The script refuses two site arguments — each site goes
+   live on its own schedule.
+2. The site must be linked (`projects/<site>/.vercel/project.json`). If it is
+   not, the script stops rather than letting the CLI create a duplicate project
+   under the team. Link with `cd projects/<site> && vercel link`.
+3. **Do not connect a Vercel project to GitHub.** It re-enables the
+   commit-author block.
+4. `.env.local` is never uploaded. Production values belong in the Vercel
+   project — set them with `printf`, not `echo` (`echo` appends a newline).
+5. Verify against the **Ready URL the script prints**. Never guess a live URL
+   from the project name.
 
 
 # Dynamic Product Data (CRITICAL)

--- a/agents/gloo.md
+++ b/agents/gloo.md
@@ -56,7 +56,7 @@ The orchestrator will provide:
 - The site's **paid domain** (e.g. `katilhospital.com.my`) and the project directory under `projects/`
 - The site's supported locales (e.g. `en`, `ms`, `zh`) — determines how many GSC URL-prefix properties to submit
 - Confirmation that the paid domain is live on Vercel with DNS pointed there
-- The deploy method for this site (Vercel git integration vs. `vercel --prod` CLI for extracted per-site repos)
+- The deploy method for this site — for sites under `projects/`, that is `scripts/deploy-site.sh <site>` from the repo root (never a raw `vercel --prod`, which is Blocked)
 
 ---
 
@@ -98,7 +98,7 @@ Follow the exact flags in the bundle's `SKILL.md` / `MANUAL-STEPS.md`. Summary:
 - **Phase 5 — Ads conversion import** (no deploy, no 24h wait). `ads-import-conversion.mjs --no-mcc --customer-id 1933757591 --domain <domain> --ga4-property-id <numeric-id> --event whatsapp_click`. It writes the `ads` block into `configs/<domain>.json` itself (`customerId`, `ga4PropertyId`, `conversionActionId`, `conversionActionName`, `event`) — Phase 6 reads it from there.
 - **Phase 6 — the four no-API toggles** (no deploy). `finalize-manual-toggles.mjs --domain <domain>` flips GA4 Signals ON, GA4 user-provided data ON, Ads counting Every→One-per-click, Ads "Import app and web metrics" ON. Idempotent — it reads state first and skips what's set. A browser window opening and driving itself is expected; screenshot proofs land in `_screenshots/<domain>/`. Use `--dry-run` to report state without changing anything, and `--only ga4-signals,ads-counting` to redo one step. "Session expired" → re-run `--login`.
 
-**Deploy discipline:** deploy Phases 3 and 4 **separately**, not batched — each phase gets its own live-site checkpoint so a break is traceable to one phase. For extracted per-site repos (no Vercel git integration), a `git push` does NOT deploy — run `vercel --prod` so the injected snippet/meta tag actually goes live before you finalize.
+**Deploy discipline:** deploy Phases 3 and 4 **separately**, not batched — each phase gets its own live-site checkpoint so a break is traceable to one phase. A `git push` does NOT deploy — these projects are not git-connected. Run `scripts/deploy-site.sh <site>` from the repo root so the injected snippet/meta tag actually goes live before you finalize. A raw `vercel --prod` is rejected as Blocked.
 
 ### 4. Verify end state
 Confirm the site now has: **GA4 property + GTM container + GSC properties (1 Domain + 1 URL-prefix per locale) + 1 Ads conversion action**. Confirm GTM is live (`view-source` on the deployed URL shows the container) and the `whatsapp_click` trigger points at `/redirect-whatsapp-1`.
@@ -140,7 +140,7 @@ Return a status report with:
 - Never run before the **paid domain** is live — Google properties must be keyed to the final URL, never a `*.vercel.app` preview.
 - Never commit, print, or forward the files in `credentials/` — keys stay at `~/.google-credentials`.
 - Follow the flags in the bundle's own `SKILL.md` / `MANUAL-STEPS.md` — they are the source of truth; don't invent flags.
-- Deploy Phases 3 and 4 separately; for extracted repos redeploy with `vercel --prod` (a push alone won't publish the snippet).
+- Deploy Phases 3 and 4 separately; redeploy with `scripts/deploy-site.sh <site>` (a push alone won't publish the snippet, and a raw `vercel --prod` is Blocked).
 - If a phase fails, stop and report which phase — do not blindly re-run later phases that depend on it.
 - The setup is not "done" until Google Signals + Ads counting/import toggles are on. Phase 6 does that — read its SUMMARY table and report the per-step verdict. If any step comes back `unverified`, `partial`, or `missing`, say so and hand that one toggle back to the user rather than declaring success.
 - Close the webcore ads-readiness card as your last action (Phase 7, `ads-readiness.mjs`), ticking exactly the items Phase 6 verified. The card is a promise to the performance marketers and completing it notifies them once — never tick to tidy a report; if a toggle is still owed, leave it unticked and say so.

--- a/agents/layla.md
+++ b/agents/layla.md
@@ -125,15 +125,29 @@ After the user confirms the website is ready:
 ### 3. Deploy to Vercel
 After the code is pushed to GitHub:
 
-- Connect the GitHub repo to Vercel (if not already connected)
-- Set the required environment variables:
+- **Deploy with the wrapper, from the repo root:**
+
+  ```bash
+  scripts/deploy-site.sh <site>              # production
+  scripts/deploy-site.sh <site> --preview    # preview first, if unsure
+  ```
+
+  Never run a raw `vercel --prod`. Vercel reads the git HEAD commit author and
+  rejects the deploy as **Blocked** — no commit author in this repo is a paid
+  member of the team. The wrapper stages the site outside git so the CLI falls
+  back to the logged-in identity. See "Deployment" in `CLAUDE.md`.
+
+- **Do NOT connect the GitHub repo to Vercel.** These projects are deliberately
+  not git-connected; connecting one re-enables the commit-author block. Pushing
+  to `main` publishes nothing — this script is the only way a site goes live.
+- Set the required environment variables **in the Vercel project** (the wrapper
+  never uploads `.env.local`), using `printf`, not `echo`:
   - `NEXT_PUBLIC_SUPABASE_URL`
   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
   - `WEBCORE_REVALIDATE_SECRET` — from the `PUT /api/website-settings` response
   - Any other project-specific env vars
-- Trigger the deployment
-- Wait for the build to complete
-- Verify the deployed site loads correctly
+- Verify the deployed site loads correctly — use the **Ready URL the script
+  prints**, never a URL guessed from the project name
 - Check that the production WhatsApp button still connects to the correct phone numbers
 - **Wire live revalidation (MANDATORY)** — register `https://<d>/api/revalidate` with `PUT /api/website-settings`, set the secret in Production, redeploy, then POST the route with the secret and require `200 {"revalidated":[...]}`. Full steps: `docs/full-website-setup.md` → Step 14 → Live revalidation. A `404` means the site has no route — add one from the template before calling it done.
 

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# Deploy one site under projects/ to Vercel.
+#
+# WHY THIS SCRIPT EXISTS
+# ----------------------
+# Vercel reads the git HEAD commit author on every CLI deploy. Only the CLI
+# login identity `chokchokchok` (utopiacoliving@gmail.com) is a paid member on
+# the `chokchunynh` team scope, and no commit author in this repo is that
+# identity -- the repo root is atyn.utopia@gmail.com, and the sites that carry
+# their own .git are atyn.utopia@, chokchunynh@ or design.utco@. So a raw
+# `vercel --prod` from projects/<site> is rejected as Blocked / Not authorized
+# before the build even runs.
+#
+# The other two repos in the workspace (utopia-webcore, website-build-playbook)
+# solve this by moving their .git aside during the upload. That is not safe
+# here: a site without its own .git resolves up to the repo root, so we would
+# have to hide the root .git -- which is shared by all 42 sites and by any other
+# session working in this checkout.
+#
+# Instead we stage the site's files into a temp directory that is not inside any
+# git repo at all, and deploy from there. The CLI finds no commit author, falls
+# back to the logged-in identity, and the repo is never touched.
+#
+# USAGE
+#   scripts/deploy-site.sh <site>              # deploy to production
+#   scripts/deploy-site.sh <site> --preview    # deploy a preview instead
+#   scripts/deploy-site.sh <site> --dry-run    # stage + check, stop before deploy
+#   scripts/deploy-site.sh                     # infer <site> from the cwd
+#   scripts/deploy-site.sh <site> -- --force   # pass extra args to vercel
+#
+# Requirements: logged in as chokchokchok (`vercel whoami`), and the site linked
+# (projects/<site>/.vercel/project.json). This repo is NOT connected to GitHub --
+# merging to main publishes nothing; this script is how a site goes live.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED_USER="chokchokchok"
+VERCEL_SCOPE="chokchunynh"
+
+SITE=""
+TARGET="production"
+DRY_RUN=0
+EXTRA_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --preview)  TARGET="preview"; shift ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    --prod|--production) TARGET="production"; shift ;;
+    --)         shift; EXTRA_ARGS+=("$@"); break ;;
+    -h|--help)  sed -n '2,40p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -*)         echo "unknown option: $1" >&2; exit 2 ;;
+    *)
+      if [ -n "$SITE" ]; then
+        echo "only one site at a time (got '$SITE' and '$1')" >&2
+        echo "one site, one deploy -- each site goes live on its own schedule." >&2
+        exit 2
+      fi
+      SITE="$1"; shift ;;
+  esac
+done
+
+# Infer the site from the cwd when run from inside projects/<site>/.
+if [ -z "$SITE" ]; then
+  here="$(pwd)"
+  case "$here" in
+    "$REPO"/projects/*)
+      rest="${here#"$REPO"/projects/}"
+      SITE="${rest%%/*}" ;;
+  esac
+fi
+
+if [ -z "$SITE" ]; then
+  echo "usage: scripts/deploy-site.sh <site> [--preview] [--dry-run]" >&2
+  echo "       (or run it from inside projects/<site>/)" >&2
+  exit 2
+fi
+
+SITE="$(basename "$SITE")"          # tolerate `projects/foo` or `projects/foo/`
+SRC="$REPO/projects/$SITE"
+
+# ─── 1. Preflight: the three things that silently waste a deploy ───────────
+if [ ! -d "$SRC" ]; then
+  echo "no such site: projects/$SITE" >&2
+  echo "available:" >&2
+  (cd "$REPO/projects" && ls -d */ | sed 's#/$##' | sed 's/^/  /') >&2
+  exit 1
+fi
+
+if [ ! -f "$SRC/.vercel/project.json" ]; then
+  echo "projects/$SITE is not linked to a Vercel project." >&2
+  echo "There is no .vercel/project.json, so a deploy would create a NEW project" >&2
+  echo "under the team rather than updating the existing site." >&2
+  echo "Link it first:  cd projects/$SITE && vercel link" >&2
+  exit 1
+fi
+
+PROJECT_NAME="$(sed -n 's/.*"projectName" *: *"\([^"]*\)".*/\1/p' "$SRC/.vercel/project.json")"
+
+# Run this from a neutral directory. Inside a linked project `vercel whoami`
+# resolves the linked scope too, so a stale or wrong .vercel/project.json makes
+# it answer "Not authorized" even when the login is fine -- which would send you
+# chasing a login problem you do not have.
+who="$(cd / && vercel whoami 2>/dev/null || true)"
+if [ "$who" != "$EXPECTED_USER" ]; then
+  echo "Vercel CLI is logged in as '${who:-<nobody>}', not '$EXPECTED_USER'." >&2
+  echo "Only $EXPECTED_USER (utopiacoliving@gmail.com) can publish on this team." >&2
+  echo "Fix:  vercel logout && vercel login" >&2
+  exit 1
+fi
+
+echo "▸ site            projects/$SITE"
+echo "▸ vercel project  ${PROJECT_NAME:-<unnamed>}"
+echo "▸ identity        $who"
+echo "▸ target          $TARGET"
+
+# ─── 2. Stage the files outside every git repo ─────────────────────────────
+STAGE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/deploy-$SITE.XXXXXX")"
+cleanup() { rm -rf "$STAGE_ROOT"; }
+trap cleanup EXIT INT TERM
+STAGE="$STAGE_ROOT/$SITE"
+mkdir -p "$STAGE"
+
+# .git            -- the whole point: no commit author for the CLI to read
+# node_modules    -- Vercel runs its own install
+# .next           -- Vercel runs its own build
+# .env*.local     -- secrets; production values live in the Vercel project
+# the rest        -- dev leftovers named in .gitignore, none of them shipped
+echo "▸ staging files (no .git, no node_modules, no secrets)"
+rsync -a \
+  --exclude '.git' \
+  --exclude '.git/' \
+  --exclude 'node_modules' \
+  --exclude '.next' \
+  --exclude '.env.local' \
+  --exclude '.env.*.local' \
+  --exclude '*.tsbuildinfo' \
+  --exclude '.DS_Store' \
+  --exclude '*.log' \
+  --exclude 'temporary screenshots' \
+  --exclude '.blog-scripts' \
+  --exclude '.cyclops-*' \
+  --exclude '.hanabi-*' \
+  "$SRC/" "$STAGE/"
+
+# The link metadata is gitignored, so rsync above may not be enough on its own --
+# copy it explicitly. Without it the CLI would prompt to create a new project.
+mkdir -p "$STAGE/.vercel"
+cp "$SRC/.vercel/project.json" "$STAGE/.vercel/project.json"
+
+# ─── 3. Prove the staged tree is really outside git ────────────────────────
+# If this assertion ever fails the deploy would be Blocked again, and the cause
+# would look like a Vercel problem rather than a staging problem. Fail loudly.
+if find "$STAGE" -name '.git' -maxdepth 3 -print -quit | grep -q .; then
+  echo "staged tree still contains a .git -- refusing to deploy" >&2
+  exit 1
+fi
+probe="$STAGE"
+while [ "$probe" != "/" ]; do
+  if [ -e "$probe/.git" ]; then
+    echo "staging dir is inside a git repo ($probe) -- refusing to deploy" >&2
+    echo "the CLI would read that repo's commit author and the deploy would be Blocked." >&2
+    exit 1
+  fi
+  probe="$(dirname "$probe")"
+done
+
+if [ -e "$STAGE/.env.local" ]; then
+  echo "staged tree contains .env.local -- refusing to upload secrets" >&2
+  exit 1
+fi
+
+echo "▸ staged at       $STAGE"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "▸ dry run: stopping before deploy"
+  echo "  staged files: $(find "$STAGE" -type f | wc -l | tr -d ' ')"
+  exit 0
+fi
+
+# ─── 4. Deploy ─────────────────────────────────────────────────────────────
+VERCEL_ARGS=(deploy --yes --scope "$VERCEL_SCOPE")
+[ "$TARGET" = "production" ] && VERCEL_ARGS+=(--prod)
+
+echo "▸ deploying…"
+OUT="$STAGE_ROOT/vercel.out"
+if ! (cd "$STAGE" && vercel "${VERCEL_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}) 2>&1 | tee "$OUT"; then
+  echo "" >&2
+  echo "✗ deploy failed. Read the output above -- the repo was not modified." >&2
+  exit 1
+fi
+
+# The Ready URL is what we verify against. Never guess it from the project name.
+URL="$(grep -Eo 'https://[a-zA-Z0-9._-]+' "$OUT" | tail -1)"
+if [ -z "$URL" ]; then
+  echo "⚠ deploy reported success but no URL was found in the output." >&2
+  echo "  Check with: vercel ls ${PROJECT_NAME:-$SITE}" >&2
+  exit 1
+fi
+
+echo ""
+echo "▸ verifying $URL"
+code="$(curl -s -o /dev/null -w '%{http_code}' "$URL" || true)"
+if [ "$code" = "200" ]; then
+  echo "✓ $URL responded 200"
+else
+  echo "⚠ $URL responded $code -- deploy went up but the page is not serving 200." >&2
+  echo "  Open it and check before calling this done." >&2
+  exit 1
+fi
+
+echo ""
+echo "✓ $SITE deployed to $TARGET: $URL"
+echo "  Open it and confirm the change is visible before calling it done."


### PR DESCRIPTION
Closes #145

## What this does

Adds `scripts/deploy-site.sh`, one command to deploy a site under `projects/`:

```bash
scripts/deploy-site.sh <site>              # production
scripts/deploy-site.sh <site> --preview    # preview
scripts/deploy-site.sh <site> --dry-run    # stage + preflight, stop before deploy
```

## Why the staging approach, not the `.git`-hiding one

The two existing wrappers (`utopia-webcore/scripts/deploy.sh`,
`website-build-playbook/deploy.sh`) move their `.git` aside during upload. That is
not safe in this repo:

- 20 of 42 sites have no `.git` of their own, so they resolve up to the **repo
  root** `.git` — hiding a site-level `.git` would not help them.
- That root `.git` is shared by all 42 sites and by any other session working in
  this checkout. Moving it away for the length of a deploy breaks them.

So instead the script `rsync`s the site into a temp dir that is not inside any git
repo and deploys from there. The CLI finds no commit author, falls back to the
logged-in identity, and **the repo is never touched**.

## Guards

- Refuses unless `vercel whoami` is `chokchokchok`
- Refuses if the site has no `.vercel/project.json` — otherwise the CLI would
  create a *duplicate* project under the team instead of updating the site
- Never uploads `.env.local` (asserted, not just excluded)
- Asserts the staged tree has no `.git` inside it **or in any parent** — if that
  ever regresses, the deploy would be Blocked again and would look like a Vercel
  fault rather than a staging fault
- Verifies the Ready URL it prints returns 200; never guesses a URL
- Refuses two site arguments (one site, one deploy)

## Docs

- `agents/layla.md` and `agents/gloo.md` prescribed raw `vercel --prod` — the
  command that fails. Now they point at the wrapper.
- Dropped layla's "Connect the GitHub repo to Vercel" step: connecting re-enables
  the commit-author block, and the workspace `DEPLOY.md` forbids it.
- Added a Deployment section to `CLAUDE.md` and `AGENTS.md` (both, matching the
  existing mirroring in those files). No design sections were touched.

## What was verified, and what was not

Verified by running it:

- preflight failures each give the right message and exit non-zero: unknown site,
  unlinked site, wrong Vercel identity, two sites
- `--dry-run` stages 122 files for `cat-rumah-malaysia`
- `.git`, `node_modules`, `.next`, `.env.local` are all absent from the staged tree,
  including planted decoys
- site inference from `cd projects/<site>` works
- fixed a real bug found in testing: `vercel whoami` run from inside a linked
  directory resolves the linked scope too, so a stale `project.json` made it answer
  "Not authorized" and the script blamed the login. It now runs `whoami` from a
  neutral directory.

**Not verified: an actual end-to-end deploy.** No site has been deployed with this
script yet, so "the deploy now succeeds instead of Blocked" is reasoned from the
documented cause, not observed. Worth one real run on a low-stakes site before
trusting it.

## Needs approval before merge

This adds a deploy script, so per the workspace `CLAUDE.md` it stops here for review
rather than self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
