### PR TITLE
Record waterproofmalaysia.my's Google automation config

### DIFF
--- a/scripts/google-automation/configs/waterproofmalaysia.my.json
+++ b/scripts/google-automation/configs/waterproofmalaysia.my.json
@@ -1,0 +1,29 @@
+{
+  "domain": "waterproofmalaysia.my",
+  "containerId": "GTM-NCQ7KPPC",
+  "gtmAccountId": "6000211475",
+  "ga4MeasurementId": "G-NQDJ36QQKL",
+  "events": [
+    {
+      "redirectPath": "/redirect-whatsapp-1",
+      "eventName": "whatsapp_click"
+    }
+  ],
+  "createdAt": "2026-09-11T07:41:11.776Z",
+  "gsc": {
+    "siteUrl": "https://waterproofmalaysia.my/zh/",
+    "token": "<meta name=\"google-site-verification\" content=\"HaSOZX7XJi0niLyMf0s7LtJSq-8Q6A7Ckp8Iu7OMDOU\" />",
+    "initAt": "2026-09-11T07:45:46.608Z",
+    "verified": true,
+    "verificationMethod": "META",
+    "verifiedAt": "2026-09-11T07:49:37.324Z"
+  },
+  "ads": {
+    "customerId": "1933757591",
+    "ga4PropertyId": "553762010",
+    "conversionActionId": "7759245780",
+    "conversionActionName": "waterproofmalaysia.my (web) whatsapp_click",
+    "event": "whatsapp_click",
+    "importedAt": "2026-09-11T07:50:31.434Z"
+  }
+}


### PR DESCRIPTION
Closes #153

Gloo completed all seven phases for `waterproofmalaysia.my` on 2026-09-11. The scripts wrote the per-site config but nothing committed it, so a re-run would not be idempotent.

| | |
|---|---|
| GTM | `GTM-NCQ7KPPC` (account `6000211475`, container `263842220`) |
| GA4 | `G-NQDJ36QQKL`, property `553762010` |
| GSC | `sc-domain:waterproofmalaysia.my` + URL-prefix `/`, `/en/`, `/zh/` — one verification token for all three |
| Ads | conversion action `7759245780` on customer `1933757591`, event `whatsapp_click` |
| Readiness | webcore card closed — signals ✅ counting ✅ metrics ✅ |

The GSC token in the file is the public site-verification value already served in the page `<meta>`; every sibling config records it the same way. No credentials.

Live checkpoints re-verified independently: GTM script + noscript and the verification meta present on `/`, `/en`, `/zh`; `gtm.js?id=GTM-NCQ7KPPC` → 200; WhatsApp redirect still DB-backed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT2jMpsbZ5HK7As7MySkUs