### PR TITLE
feat(electric-wheelchair): find-your-town search in the locations section

### DIFF
--- a/projects/electric-wheelchair-malaysia/app/globals.css
+++ b/projects/electric-wheelchair-malaysia/app/globals.css
@@ -1386,3 +1386,34 @@ p, li, blockquote,
   .ew-nearby__chips { justify-content: flex-start; }
   .ew-intro__inner { justify-items: start; text-align: left; }
 }
+
+/* ── Locations: find your town ─────────────────────────────────────────── */
+.ew-find { max-width: 820px; margin: 0 auto; display: grid; gap: 16px; }
+.ew-find__search {
+  display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
+  border: 1.5px solid var(--hair-strong); border-radius: 14px; padding: 6px 6px 6px 16px; background: #fff;
+}
+.ew-find__search:focus-within { border-color: var(--brand-navy); }
+.ew-find__search input { border: 0; outline: 0; font: 500 16px/1.2 var(--font-inter), Inter, sans-serif; color: var(--brand-navy); background: transparent; min-width: 0; padding: 8px 0; }
+.ew-find__search input::placeholder { color: #8A96AC; }
+.ew-find__search input::-webkit-search-cancel-button { -webkit-appearance: none; }
+.ew-find__search span { font-size: 12px; color: var(--ink-muted); padding: 10px 12px; background: var(--brand-ice); border-radius: 9px; white-space: nowrap; }
+.ew-find__filters { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
+.ew-find__filters button {
+  border: 1px solid var(--hair-strong); background: #fff; color: var(--brand-navy); border-radius: 999px;
+  padding: 7px 12px; font: 600 12.5px/1 var(--font-inter), Inter, sans-serif; cursor: pointer;
+  transition: transform 150ms var(--ease-out);
+}
+.ew-find__filters button:hover { border-color: var(--brand-navy); }
+.ew-find__filters button:active { transform: scale(0.97); }
+.ew-find__filters button:focus-visible { outline: 3px solid var(--brand-orange-deep); outline-offset: 2px; }
+.ew-find__filters button[aria-pressed="true"] { background: var(--brand-navy); border-color: var(--brand-navy); color: #fff; }
+.ew-find__list { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+.ew-find__list a { display: grid; gap: 2px; padding: 12px 14px; border: 1px solid var(--hair); border-radius: 12px; background: #fff; text-decoration: none; transition: transform 150ms var(--ease-out); }
+.ew-find__list a:hover { border-color: var(--brand-navy); transform: translateY(-1px); }
+.ew-find__list a:focus-visible { outline: 3px solid var(--brand-orange-deep); outline-offset: 2px; }
+.ew-find__list b { font-size: 14.5px; font-weight: 600; color: var(--brand-navy); }
+.ew-find__list small { font-size: 12px; color: var(--ink-muted); }
+.ew-find__empty, .ew-find__more { text-align: center; font-size: 13.5px; color: var(--ink-muted); margin: 0; }
+.ew-find__more button { border: 0; background: none; padding: 0; font: 600 13.5px/1.4 var(--font-inter), Inter, sans-serif; color: var(--brand-orange-deep); cursor: pointer; text-decoration: underline; text-underline-offset: 3px; }
+@media (min-width: 900px) { .ew-find__list { grid-template-columns: repeat(4, 1fr); } }

--- a/projects/electric-wheelchair-malaysia/components/LocationFinder.tsx
+++ b/projects/electric-wheelchair-malaysia/components/LocationFinder.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+export interface FinderTown {
+  slug: string;
+  name: string;
+  state: string;
+  href: string;
+}
+
+export interface FinderLabels {
+  placeholder: string;
+  all: string;
+  /** "{n} towns" — the count next to the search box. */
+  count: string;
+  /** "Showing {shown} of {n} — …" under the list when it is collapsed. */
+  more: string;
+  /** "Show all {n}" — the button that expands the collapsed list. */
+  showAll: string;
+  /** "No town called “{q}” yet — …" */
+  empty: string;
+}
+
+const INITIAL = 12;
+
+/**
+ * Type-to-find over the town list. Every town link is rendered on the server
+ * and stays in the DOM — filtering only toggles `hidden` — so crawlers see all
+ * 84 internal links while a phone user sees twelve until they type or pick a
+ * state.
+ */
+export default function LocationFinder({
+  towns,
+  states,
+  labels,
+}: {
+  towns: FinderTown[];
+  states: string[];
+  labels: FinderLabels;
+}) {
+  const [query, setQuery] = useState('');
+  const [state, setState] = useState('');
+  const [expanded, setExpanded] = useState(false);
+
+  const q = query.trim().toLowerCase();
+  const filtering = q.length > 0 || state.length > 0;
+
+  const matches = useMemo(
+    () => towns.filter((t) => (!state || t.state === state) && (!q || t.name.toLowerCase().includes(q))),
+    [towns, state, q],
+  );
+  const visible = new Set((filtering || expanded ? matches : matches.slice(0, INITIAL)).map((t) => t.slug));
+  const fill = (s: string) => s.replace('{n}', String(matches.length)).replace('{shown}', String(INITIAL)).replace('{q}', query.trim());
+
+  return (
+    <div className="ew-find">
+      <label className="ew-find__search">
+        <input
+          id="location-finder"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={labels.placeholder}
+          autoComplete="off"
+          aria-label={labels.placeholder}
+        />
+        <span aria-live="polite">{fill(labels.count)}</span>
+      </label>
+
+      <div className="ew-find__filters" role="group">
+        <button type="button" aria-pressed={state === ''} onClick={() => setState('')}>
+          {labels.all}
+        </button>
+        {states.map((s) => (
+          <button key={s} type="button" aria-pressed={state === s} onClick={() => setState(state === s ? '' : s)}>
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <div className="ew-find__list">
+        {towns.map((t) => (
+          <a key={t.slug} href={t.href} hidden={!visible.has(t.slug)}>
+            <b>{t.name}</b>
+            <small>{t.state}</small>
+          </a>
+        ))}
+      </div>
+
+      {matches.length === 0 && <p className="ew-find__empty">{fill(labels.empty)}</p>}
+
+      {!filtering && !expanded && matches.length > INITIAL && (
+        <p className="ew-find__more">
+          {fill(labels.more)}{' '}
+          <button type="button" onClick={() => setExpanded(true)}>
+            {fill(labels.showAll)}
+          </button>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/projects/electric-wheelchair-malaysia/components/sections/LocationsSection.tsx
+++ b/projects/electric-wheelchair-malaysia/components/sections/LocationsSection.tsx
@@ -1,38 +1,43 @@
 import { getTranslations } from 'next-intl/server';
 import { siteConfig } from '@/config/site';
 import { regionOrder, getLocationsByRegion } from '@/config/locations';
+import LocationFinder, { type FinderTown } from '@/components/LocationFinder';
 
-/** Every location page, grouped by region — the site's internal-link spine. */
+/** Find your town: search + state filters over every location page link. */
 export default async function LocationsSection({ locale }: { locale: string }) {
   const t = await getTranslations({ locale, namespace: 'locations' });
   const byRegion = getLocationsByRegion();
+
+  const states = regionOrder.filter((region) => (byRegion[region] ?? []).length > 0);
+  const towns: FinderTown[] = states.flatMap((region) =>
+    (byRegion[region] ?? []).map((loc) => ({
+      slug: loc.slug,
+      name: loc.name,
+      state: region,
+      href: `/${locale}/${siteConfig.productSlug}/${loc.slug}`,
+    })),
+  );
 
   return (
     <section className="ew-sec ew-sec--paper" id="locations">
       <div className="ew-wrap">
         <div className="ew-head">
           <span className="ew-eyebrow">{t('eyebrow')}</span>
-          <h3>{t('heading')}</h3>
-          <p>{t('subheading')}</p>
+          <h3>{t('finderHeading')}</h3>
+          <p>{t('finderSubheading', { n: towns.length })}</p>
         </div>
-        <div className="ew-locs">
-          {regionOrder.map((region) => {
-            const regionLocations = byRegion[region] ?? [];
-            if (regionLocations.length === 0) return null;
-            return (
-              <div className="ew-locs__region" key={region}>
-                <h4>{region}</h4>
-                <div className="ew-locs__chips">
-                  {regionLocations.map((loc) => (
-                    <a key={loc.slug} href={`/${locale}/${siteConfig.productSlug}/${loc.slug}`}>
-                      {loc.name}
-                    </a>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        <LocationFinder
+          towns={towns}
+          states={states}
+          labels={{
+            placeholder: t('finderPlaceholder'),
+            all: t('finderAll'),
+            count: t('finderCount'),
+            more: t('finderMore'),
+            showAll: t('finderShowAll'),
+            empty: t('finderEmpty'),
+          }}
+        />
       </div>
     </section>
   );

--- a/projects/electric-wheelchair-malaysia/messages/en.json
+++ b/projects/electric-wheelchair-malaysia/messages/en.json
@@ -270,7 +270,15 @@
     "heading": "We Deliver Across Malaysia",
     "subheading": "Same-day delivery to 80+ cities nationwide",
     "viewAll": "View All Locations",
-    "eyebrow": "Where we deliver"
+    "eyebrow": "Where we deliver",
+    "finderHeading": "Find your town",
+    "finderSubheading": "{n} towns across Malaysia. Type yours, or pick a state.",
+    "finderPlaceholder": "Type your town, e.g. Shah Alam",
+    "finderAll": "All",
+    "finderCount": "{n} towns",
+    "finderMore": "Showing {shown} of {n}.",
+    "finderShowAll": "Show all {n}",
+    "finderEmpty": "No town called “{q}” yet — WhatsApp us, we deliver most places."
   },
   "faq": {
     "heading": "Frequently Asked Questions",

--- a/projects/electric-wheelchair-malaysia/messages/ms.json
+++ b/projects/electric-wheelchair-malaysia/messages/ms.json
@@ -274,7 +274,15 @@
     "heading": "Kami Menghantar Ke Seluruh Malaysia",
     "subheading": "Penghantaran hari sama ke 80+ bandar di seluruh negara",
     "viewAll": "Lihat Semua Lokasi",
-    "eyebrow": "Kawasan penghantaran"
+    "eyebrow": "Kawasan penghantaran",
+    "finderHeading": "Cari bandar anda",
+    "finderSubheading": "{n} bandar di seluruh Malaysia. Taip bandar anda, atau pilih negeri.",
+    "finderPlaceholder": "Taip bandar anda, cth. Shah Alam",
+    "finderAll": "Semua",
+    "finderCount": "{n} bandar",
+    "finderMore": "Menunjukkan {shown} daripada {n}.",
+    "finderShowAll": "Tunjuk semua {n}",
+    "finderEmpty": "Belum ada bandar bernama “{q}” — WhatsApp kami, kami hantar ke kebanyakan tempat."
   },
   "faq": {
     "heading": "Soalan Lazim",

--- a/projects/electric-wheelchair-malaysia/messages/zh.json
+++ b/projects/electric-wheelchair-malaysia/messages/zh.json
@@ -270,7 +270,15 @@
     "heading": "全马送货服务",
     "subheading": "全国80+城市当日送达",
     "viewAll": "查看所有地区",
-    "eyebrow": "配送范围"
+    "eyebrow": "配送范围",
+    "finderHeading": "查找您的城镇",
+    "finderSubheading": "覆盖马来西亚 {n} 个城镇。输入您的城镇，或选择州属。",
+    "finderPlaceholder": "输入您的城镇，例如 Shah Alam",
+    "finderAll": "全部",
+    "finderCount": "{n} 个城镇",
+    "finderMore": "显示 {n} 个中的 {shown} 个。",
+    "finderShowAll": "显示全部 {n} 个",
+    "finderEmpty": "暂无名为“{q}”的城镇——请 WhatsApp 联系我们，大多数地区我们都能配送。"
   },
   "faq": {
     "heading": "常见问题",


### PR DESCRIPTION
Closes #161

Search + state filters + a card per town, replacing the wall of 84 pills. Twelve towns show until the visitor types or picks a state; every link stays in the DOM for crawlers (filtering toggles `hidden`).

### Verified
- `npm run build` passes; served homepage has 84 town links in the section, 72 with `hidden`, one h1 and one h2.
- Driven in a real browser: 12 visible at rest; typing "sha" leaves exactly one card, Shah Alam.
- No horizontal overflow at 390px or 1440px; looked at both.

Copy in en, ms and zh.

Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)