### PR TITLE
style(electric-wheelchair): orange eyebrow, brand-CI button radius, gradient USP icons

### DIFF
--- a/projects/electric-wheelchair-malaysia/app/globals.css
+++ b/projects/electric-wheelchair-malaysia/app/globals.css
@@ -985,8 +985,10 @@ p, li, blockquote,
 
 /* DESIGN.md, Shapes: one button shape across the whole site — only colour
    separates the variants. These sites had pills, which disagreed with every
-   other surface. */
-.wa-btn, .ghost-btn { border-radius: 12px; }
+   other surface. Radius is the Utopia CI structural token (--r-button, 8px) —
+   the same one the "Built by Utopia AI" footer credit uses — per the client's
+   request to have the CTA follow brand CI. */
+.wa-btn, .ghost-btn { border-radius: var(--r-button, 8px); }
 .wa-btn { padding: 0 28px; height: 52px; font-size: 15px; }
 .ghost-btn { padding: 0 28px; height: 52px; font-size: 15px; border-width: 1.5px; }
 .wa-btn:hover { transform: translateY(-1px); }
@@ -1286,11 +1288,16 @@ p, li, blockquote,
    navy final-CTA ground it goes translucent white. */
 .ew-eyebrow {
   display: inline-block; padding: 6px 12px; border-radius: 999px;
-  background: #FFF3EA; color: var(--brand-orange-deep);
+  /* Solid orange, white text — brand-orange-deep (#B84D0A) rather than the
+     bright #FF6613: white on the bright orange is 2.9:1 and fails AA, white
+     on the deep orange is 5.1:1. */
+  background: var(--brand-orange-deep); color: #fff;
   font-family: var(--font-heading); font-size: 0.75rem; font-weight: 700;
   line-height: 1; letter-spacing: 0.08em; text-transform: uppercase;
 }
 .ew-hero__copy .ew-eyebrow { margin-bottom: 2px; }
+/* The steps section itself sits on brand orange, so its eyebrow inverts to
+   white-on-navy instead of orange-on-orange. */
 .ew-steps .ew-eyebrow { background: #fff; color: var(--brand-navy); }
 .ew-eyebrow--on-dark { background: rgba(255, 255, 255, 0.14); color: #fff; }
 
@@ -1303,7 +1310,14 @@ p, li, blockquote,
 }
 
 /* ── Icons in the USP bar and the spec list ─────────────────────────────── */
-.ew-usp__icon { display: inline-grid; place-items: center; color: var(--brand-orange-deep); margin-bottom: 2px; }
+/* USP icons sit in a round gradient-orange badge; the spec-list icons stay
+   plain (they're inline with dense rows, a badge there would be too heavy). */
+.ew-usp__icon {
+  width: 44px; height: 44px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand-orange) 0%, var(--brand-orange-deep) 100%);
+  color: #fff; display: grid; place-items: center; margin-bottom: 4px;
+  box-shadow: 0 6px 16px rgba(184, 77, 10, 0.28);
+}
 .ew-specs > div { grid-template-columns: 128px 1fr; }
 .ew-specs dt { display: flex; align-items: center; gap: 8px; }
 .ew-specs__icon { display: inline-grid; place-items: center; color: var(--brand-orange-deep); flex: none; }


### PR DESCRIPTION
Closes #163

- Eyebrow badge: solid `--brand-orange-deep` background, white text (checked: 5.1:1, AA-safe; the bright orange would have been 2.9:1).
- `.wa-btn`/`.ghost-btn` radius: `var(--r-button)` (Utopia CI, 8px) instead of a hardcoded 12px.
- USP icons: round gradient-orange badge (135deg, brand-orange → brand-orange-deep), white glyph.

### Verified
- `npm run build` passes; served build: one h1/h2, 8 eyebrows, 3 USP icon badges; no overflow at 390px or 1440px; looked at both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)